### PR TITLE
fix(metrics): downgrade WebSocket close logging to appropriate levels

### DIFF
--- a/internal/metrics/websocket.go
+++ b/internal/metrics/websocket.go
@@ -416,7 +416,7 @@ func (c *WebSocketClient) readPump() {
 	for {
 		_, _, err := c.conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 				c.hub.logger.WithFields(map[string]any{
 					"error":     err.Error(),
 					"component": "websocket",
@@ -453,7 +453,7 @@ func (c *WebSocketClient) writePump() {
 					c.hub.logger.WithFields(map[string]any{
 						"error":     err.Error(),
 						"component": "websocket",
-					}).Error("Failed to write close message")
+					}).Debug("Failed to write close message")
 				}
 				return
 			}


### PR DESCRIPTION
Closes #81

## Summary

- Add `websocket.CloseNormalClosure` (code 1000) to expected close codes in `readPump`, preventing normal disconnects from being logged as ERROR
- Downgrade "Failed to write close message" from ERROR to DEBUG in `writePump`, since writing a close frame to an already-closed connection is expected during normal disconnect flows

## Test plan

- [x] `make test-ci` passes
- [ ] Connect to WebSocket, disconnect normally, verify no ERROR logs for close code 1000