### PR TITLE
fix(devices): use correct ip field name + harden UpdateDevice conflict handling

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -371,6 +371,28 @@ func (h *Handler) UpdateDevice(w http.ResponseWriter, r *http.Request) {
 	// Update existing device with new data
 	updatedDevice.ID = existingDevice.ID
 	if err := h.DB.UpdateDevice(&updatedDevice); err != nil {
+		h.logger.WithFields(map[string]any{
+			"error":      err.Error(),
+			"device_id":  updatedDevice.ID,
+			"device_ip":  updatedDevice.IP,
+			"device_mac": updatedDevice.MAC,
+			"component":  "api",
+			"operation":  "update_device",
+			"request_id": r.Context().Value("request_id"),
+		}).Error("UpdateDevice operation failed with detailed context")
+
+		if strings.Contains(strings.ToLower(err.Error()), "unique constraint") ||
+			strings.Contains(strings.ToLower(err.Error()), "constraint failed") {
+			if strings.Contains(strings.ToLower(err.Error()), "ip") {
+				h.responseWriter().WriteError(w, r, http.StatusConflict, apiresp.ErrCodeConflict, "Device with this IP address already exists", nil)
+			} else if strings.Contains(strings.ToLower(err.Error()), "mac") {
+				h.responseWriter().WriteError(w, r, http.StatusConflict, apiresp.ErrCodeConflict, "Device with this MAC address already exists", nil)
+			} else {
+				h.responseWriter().WriteError(w, r, http.StatusConflict, apiresp.ErrCodeConflict, "Device conflict", nil)
+			}
+			return
+		}
+
 		h.responseWriter().WriteInternalError(w, r, err)
 		return
 	}

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -324,6 +324,40 @@ func TestUpdateDevice(t *testing.T) {
 	testutil.AssertEqual(t, "Updated Device Name", dbDevice.Name)
 }
 
+func TestUpdateDevice_IPConflict(t *testing.T) {
+	db, cleanup := testutil.TestDatabase(t)
+	defer cleanup()
+	svc := testShellyService(t, db)
+	notificationHandler := testNotificationHandler(t, db)
+	handler := NewHandlerWithLogger(db, svc, notificationHandler, nil, logging.GetDefault())
+
+	// Seed two devices with distinct IPs/MACs
+	d1 := testutil.TestDevice()
+	d1.IP = "192.168.1.10"
+	d1.MAC = "AA:BB:CC:DD:EE:01"
+	testutil.AssertNoError(t, db.AddDevice(d1))
+
+	d2 := testutil.TestDevice()
+	d2.IP = "192.168.1.20"
+	d2.MAC = "AA:BB:CC:DD:EE:02"
+	testutil.AssertNoError(t, db.AddDevice(d2))
+
+	// Attempt to update d2 to reuse d1's IP
+	updated := *d2
+	updated.IP = d1.IP
+	body, err := json.Marshal(updated)
+	testutil.AssertNoError(t, err)
+
+	req := httptest.NewRequest("PUT", "/api/v1/devices/"+strconv.Itoa(int(d2.ID)), bytes.NewReader(body))
+	req = mux.SetURLVars(req, map[string]string{"id": strconv.Itoa(int(d2.ID))})
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.UpdateDevice(w, req)
+
+	testutil.AssertEqual(t, http.StatusConflict, w.Code)
+}
+
 func TestUpdateDevice_NotFound(t *testing.T) {
 	db, cleanup := testutil.TestDatabase(t)
 	defer cleanup()

--- a/ui/src/components/devices/DeviceForm.vue
+++ b/ui/src/components/devices/DeviceForm.vue
@@ -28,10 +28,10 @@
     </div>
 
     <div class="form-group">
-      <label for="ipAddress">IP Address *</label>
+      <label for="ip">IP Address *</label>
       <input
-        id="ipAddress"
-        v-model="formData.ipAddress"
+        id="ip"
+        v-model="formData.ip"
         type="text"
         class="form-input"
         required
@@ -87,7 +87,7 @@ const emit = defineEmits<{
 const formData = reactive({
   name: '',
   type: '',
-  ipAddress: '',
+  ip: '',
   mac: ''
 })
 
@@ -99,7 +99,7 @@ watch(() => props.device, (device) => {
   if (device) {
     formData.name = device.name || ''
     formData.type = device.type || ''
-    formData.ipAddress = device.ipAddress || ''
+    formData.ip = device.ip || ''
     formData.mac = device.mac || ''
   }
 }, { immediate: true })
@@ -111,7 +111,7 @@ function handleSubmit() {
   const data: Partial<Device> = {
     name: formData.name,
     type: formData.type,
-    ipAddress: formData.ipAddress
+    ip: formData.ip
   }
 
   if (formData.mac) {
@@ -125,7 +125,7 @@ defineExpose({
   reset: () => {
     formData.name = ''
     formData.type = ''
-    formData.ipAddress = ''
+    formData.ip = ''
     formData.mac = ''
     error.value = ''
     isSubmitting.value = false


### PR DESCRIPTION
## Summary

- Fix `DeviceForm.vue` field-name mismatch: form used `ipAddress` but both the TS `Device` interface and the backend `database.Device` JSON tag use `ip`. Create/update submitted an unknown `ipAddress` field which the backend silently ignored, saving devices with empty IPs and then tripping UNIQUE constraints on subsequent operations.
- Harden `UpdateDevice` to map unique-constraint errors to 409 Conflict, mirroring `AddDevice`. Previously returned 500 because the conflict mapping was missing.
- Add `TestUpdateDevice_IPConflict` regression coverage.

### Why this was broken

1. Frontend sent `{ipAddress: "1.2.3.4", ...}` → backend unmarshalled into `database.Device` which only binds `json:"ip"` → device saved with `ip=""` and `mac=""`.
2. The first such save succeeded. The next create returned 409 (UNIQUE on empty `ip` or `mac`).
3. Editing an existing device pre-populated `formData.ipAddress = device.ipAddress` (always `undefined` → `""`) and submitted the blank value, wiping the real IP/MAC — then UNIQUE violation returned 500 because `UpdateDevice` lacked conflict detection.

Fixes/closes #132.

## Test plan

- [x] `go test ./internal/api/... -run 'TestUpdateDevice|TestAddDevice'` — all pass
- [x] `npx vitest run` device specs (38 tests) — all pass
- [x] `npm run build` — clean
- [x] Manual: create a new device with valid IP/MAC — 201
- [x] Manual: edit an existing device (change name, keep IP) — 200, fields preserved
- [x] Manual: delete a device with confirmation — 204
- [ ] `make test-ci` before merge
