### PR TITLE
fix(drift): align TS types and pages with backend DriftDetection API

### DIFF
--- a/ui/src/api/__tests__/drift.test.ts
+++ b/ui/src/api/__tests__/drift.test.ts
@@ -1,16 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Mock the axios client
-vi.mock('../client', () => {
-  return {
-    default: {
-      get: vi.fn(),
-      post: vi.fn(),
-      put: vi.fn(),
-      delete: vi.fn()
-    }
+vi.mock('../client', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn()
   }
-})
+}))
 
 import api from '../client'
 import {
@@ -23,693 +20,262 @@ import {
   getDriftScheduleRuns,
   getDriftReports,
   getDriftTrends,
-  resolveDriftReport,
+  resolveDriftTrend,
   generateDeviceDriftReport,
+  computeDailyAggregates,
   type DriftSchedule,
   type DriftScheduleRun,
-  type DriftReport,
   type DriftTrend,
+  type DriftReport,
   type CreateDriftScheduleRequest
 } from '../drift'
 
-describe('Drift Detection API', () => {
+function ok<T>(data: T) {
+  return { data: { success: true, data, meta: { version: 'v1' }, timestamp: '2026-04-13T00:00:00Z' } }
+}
+
+function fail(message: string) {
+  return { data: { success: false, error: { code: 'ERR', message }, meta: { version: 'v1' }, timestamp: '2026-04-13T00:00:00Z' } }
+}
+
+describe('Drift API client', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
   describe('listDriftSchedules', () => {
-    it('returns list of drift schedules with default pagination', async () => {
-      const schedules: DriftSchedule[] = [
-        {
-          id: 1,
-          name: 'Daily Check',
-          description: 'Check all devices daily',
-          deviceIds: [1, 2, 3],
-          checkInterval: '24h',
-          enabled: true,
-          lastRun: '2023-01-01T00:00:00Z',
-          nextRun: '2023-01-02T00:00:00Z',
-          createdAt: '2023-01-01T00:00:00Z',
-          updatedAt: '2023-01-01T00:00:00Z'
-        }
-      ]
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { schedules },
-          meta: { total: 1, page: 1, pageSize: 25 },
-          timestamp: new Date().toISOString()
-        }
-      })
+    it('unwraps raw array at data (no schedules wrapper)', async () => {
+      const schedules: DriftSchedule[] = [{
+        id: 1, name: 'Daily', enabled: true, cron_spec: '0 0 * * *',
+        device_ids: [1, 2], device_filter: null, last_run: null, next_run: null,
+        run_count: 0, created_at: '2026-04-13T00:00:00Z', updated_at: '2026-04-13T00:00:00Z'
+      }]
+      vi.mocked(api.get).mockResolvedValueOnce(ok(schedules))
 
       const result = await listDriftSchedules()
 
-      expect(result.items).toEqual(schedules)
-      expect(result.meta).toEqual({ total: 1, page: 1, pageSize: 25 })
       expect(api.get).toHaveBeenCalledWith('/config/drift-schedules', {
         params: { page: 1, page_size: 25 }
       })
+      expect(result.items).toEqual(schedules)
+      expect(result.items[0].cron_spec).toBe('0 0 * * *')
     })
 
-    it('returns list with custom pagination', async () => {
-      const schedules: DriftSchedule[] = []
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { schedules },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      const result = await listDriftSchedules(2, 50)
-
+    it('returns empty items when data is absent', async () => {
+      vi.mocked(api.get).mockResolvedValueOnce(ok(undefined))
+      const result = await listDriftSchedules()
       expect(result.items).toEqual([])
-      expect(api.get).toHaveBeenCalledWith('/config/drift-schedules', {
-        params: { page: 2, page_size: 50 }
-      })
     })
 
-    it('throws error when request fails', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Database error', code: 'DB_ERROR' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(listDriftSchedules()).rejects.toThrow('Database error')
-    })
-
-    it('throws default error when no error message provided', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: { success: false, timestamp: new Date().toISOString() }
-      })
-
-      await expect(listDriftSchedules()).rejects.toThrow('Failed to load drift schedules')
+    it('throws when success is false', async () => {
+      vi.mocked(api.get).mockResolvedValueOnce(fail('boom'))
+      await expect(listDriftSchedules()).rejects.toThrow('boom')
     })
   })
 
   describe('getDriftSchedule', () => {
-    it('returns a single drift schedule', async () => {
+    it('fetches one schedule by id', async () => {
       const schedule: DriftSchedule = {
-        id: 1,
-        name: 'Hourly Check',
-        checkInterval: '1h',
-        enabled: true,
-        createdAt: '2023-01-01T00:00:00Z',
-        updatedAt: '2023-01-01T00:00:00Z'
+        id: 7, name: 'Hourly', enabled: true, cron_spec: '0 * * * *',
+        run_count: 3, created_at: '2026-04-13T00:00:00Z', updated_at: '2026-04-13T00:00:00Z'
       }
-      ;(api.get as any).mockResolvedValue({
-        data: { success: true, data: schedule, timestamp: new Date().toISOString() }
-      })
+      vi.mocked(api.get).mockResolvedValueOnce(ok(schedule))
 
-      const result = await getDriftSchedule(1)
+      const result = await getDriftSchedule(7)
 
-      expect(result).toEqual(schedule)
-      expect(api.get).toHaveBeenCalledWith('/config/drift-schedules/1')
-    })
-
-    it('accepts string ID', async () => {
-      const schedule: DriftSchedule = {
-        id: 123,
-        name: 'Test',
-        checkInterval: '1h',
-        enabled: false,
-        createdAt: '2023-01-01T00:00:00Z',
-        updatedAt: '2023-01-01T00:00:00Z'
-      }
-      ;(api.get as any).mockResolvedValue({
-        data: { success: true, data: schedule, timestamp: new Date().toISOString() }
-      })
-
-      const result = await getDriftSchedule('123')
-
-      expect(result).toEqual(schedule)
-      expect(api.get).toHaveBeenCalledWith('/config/drift-schedules/123')
-    })
-
-    it('throws error when request fails', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Not found', code: 'NOT_FOUND' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(getDriftSchedule(999)).rejects.toThrow('Not found')
-    })
-
-    it('throws error when data is missing', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: { success: true, timestamp: new Date().toISOString() }
-      })
-
-      await expect(getDriftSchedule(1)).rejects.toThrow('Failed to load drift schedule')
+      expect(api.get).toHaveBeenCalledWith('/config/drift-schedules/7')
+      expect(result.cron_spec).toBe('0 * * * *')
     })
   })
 
   describe('createDriftSchedule', () => {
-    it('creates a new drift schedule', async () => {
-      const request: CreateDriftScheduleRequest = {
-        name: 'New Schedule',
-        description: 'Test schedule',
-        deviceIds: [1, 2],
-        checkInterval: '6h',
-        enabled: true
+    it('posts snake_case fields and returns created schedule', async () => {
+      const req: CreateDriftScheduleRequest = {
+        name: 'Every 6h', cron_spec: '0 */6 * * *', device_ids: [1, 2], enabled: true
       }
-      const created: DriftSchedule = {
-        id: 5,
-        ...request,
-        createdAt: '2023-01-01T00:00:00Z',
-        updatedAt: '2023-01-01T00:00:00Z'
-      }
-      ;(api.post as any).mockResolvedValue({
-        data: { success: true, data: created, timestamp: new Date().toISOString() }
-      })
+      vi.mocked(api.post).mockResolvedValueOnce(ok({ id: 42, ...req, run_count: 0, created_at: 'x', updated_at: 'x' }))
 
-      const result = await createDriftSchedule(request)
+      const result = await createDriftSchedule(req)
 
-      expect(result).toEqual(created)
-      expect(api.post).toHaveBeenCalledWith('/config/drift-schedules', request)
+      expect(api.post).toHaveBeenCalledWith('/config/drift-schedules', req)
+      expect(result.id).toBe(42)
+      expect(result.cron_spec).toBe('0 */6 * * *')
     })
 
-    it('throws error when creation fails', async () => {
-      const request: CreateDriftScheduleRequest = {
-        name: 'Bad Schedule',
-        checkInterval: 'invalid'
-      }
-      ;(api.post as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Invalid interval', code: 'VALIDATION_ERROR' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(createDriftSchedule(request)).rejects.toThrow('Invalid interval')
-    })
-
-    it('throws default error when no data returned', async () => {
-      ;(api.post as any).mockResolvedValue({
-        data: { success: true, timestamp: new Date().toISOString() }
-      })
-
-      await expect(createDriftSchedule({ name: 'Test', checkInterval: '1h' })).rejects.toThrow(
-        'Failed to create drift schedule'
-      )
+    it('throws when backend rejects', async () => {
+      vi.mocked(api.post).mockResolvedValueOnce(fail('invalid cron'))
+      await expect(createDriftSchedule({ name: 'X', cron_spec: 'bad' })).rejects.toThrow('invalid cron')
     })
   })
 
   describe('updateDriftSchedule', () => {
-    it('updates an existing drift schedule', async () => {
-      const updates = { name: 'Updated Name', enabled: false }
-      const updated: DriftSchedule = {
-        id: 1,
-        name: 'Updated Name',
-        checkInterval: '1h',
-        enabled: false,
-        createdAt: '2023-01-01T00:00:00Z',
-        updatedAt: '2023-01-02T00:00:00Z'
-      }
-      ;(api.put as any).mockResolvedValue({
-        data: { success: true, data: updated, timestamp: new Date().toISOString() }
-      })
+    it('puts partial update', async () => {
+      vi.mocked(api.put).mockResolvedValueOnce(ok({
+        id: 1, name: 'Renamed', enabled: true, cron_spec: '0 0 * * *',
+        run_count: 0, created_at: 'x', updated_at: 'x'
+      }))
 
-      const result = await updateDriftSchedule(1, updates)
+      const result = await updateDriftSchedule(1, { name: 'Renamed' })
 
-      expect(result).toEqual(updated)
-      expect(api.put).toHaveBeenCalledWith('/config/drift-schedules/1', updates)
-    })
-
-    it('accepts string ID', async () => {
-      const updates = { checkInterval: '12h' }
-      const updated: DriftSchedule = {
-        id: 42,
-        name: 'Test',
-        checkInterval: '12h',
-        enabled: true,
-        createdAt: '2023-01-01T00:00:00Z',
-        updatedAt: '2023-01-01T00:00:00Z'
-      }
-      ;(api.put as any).mockResolvedValue({
-        data: { success: true, data: updated, timestamp: new Date().toISOString() }
-      })
-
-      const result = await updateDriftSchedule('42', updates)
-
-      expect(result).toEqual(updated)
-      expect(api.put).toHaveBeenCalledWith('/config/drift-schedules/42', updates)
-    })
-
-    it('throws error when update fails', async () => {
-      ;(api.put as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Schedule not found', code: 'NOT_FOUND' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(updateDriftSchedule(999, { name: 'Test' })).rejects.toThrow(
-        'Schedule not found'
-      )
+      expect(api.put).toHaveBeenCalledWith('/config/drift-schedules/1', { name: 'Renamed' })
+      expect(result.name).toBe('Renamed')
     })
   })
 
   describe('deleteDriftSchedule', () => {
-    it('deletes a drift schedule', async () => {
-      ;(api.delete as any).mockResolvedValue({
-        data: { success: true, timestamp: new Date().toISOString() }
-      })
-
-      await deleteDriftSchedule(1)
-
-      expect(api.delete).toHaveBeenCalledWith('/config/drift-schedules/1')
-    })
-
-    it('accepts string ID', async () => {
-      ;(api.delete as any).mockResolvedValue({
-        data: { success: true, timestamp: new Date().toISOString() }
-      })
-
-      await deleteDriftSchedule('42')
-
-      expect(api.delete).toHaveBeenCalledWith('/config/drift-schedules/42')
-    })
-
-    it('throws error when deletion fails', async () => {
-      ;(api.delete as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Cannot delete active schedule', code: 'CONFLICT' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(deleteDriftSchedule(1)).rejects.toThrow('Cannot delete active schedule')
-    })
-
-    it('throws default error when no error message provided', async () => {
-      ;(api.delete as any).mockResolvedValue({
-        data: { success: false, timestamp: new Date().toISOString() }
-      })
-
-      await expect(deleteDriftSchedule(1)).rejects.toThrow('Failed to delete drift schedule')
+    it('deletes and returns void', async () => {
+      vi.mocked(api.delete).mockResolvedValueOnce(ok({ status: 'deleted' }))
+      await expect(deleteDriftSchedule(5)).resolves.toBeUndefined()
+      expect(api.delete).toHaveBeenCalledWith('/config/drift-schedules/5')
     })
   })
 
   describe('toggleDriftSchedule', () => {
-    it('toggles a drift schedule enabled status', async () => {
-      const toggled: DriftSchedule = {
-        id: 1,
-        name: 'Test',
-        checkInterval: '1h',
-        enabled: false,
-        createdAt: '2023-01-01T00:00:00Z',
-        updatedAt: '2023-01-01T00:00:00Z'
-      }
-      ;(api.post as any).mockResolvedValue({
-        data: { success: true, data: toggled, timestamp: new Date().toISOString() }
-      })
-
+    it('posts and returns toggled schedule', async () => {
+      vi.mocked(api.post).mockResolvedValueOnce(ok({
+        id: 1, name: 'X', enabled: false, cron_spec: '0 0 * * *',
+        run_count: 0, created_at: 'x', updated_at: 'x'
+      }))
       const result = await toggleDriftSchedule(1)
-
-      expect(result).toEqual(toggled)
-      expect(api.post).toHaveBeenCalledWith('/config/drift-schedules/1/toggle')
-    })
-
-    it('accepts string ID', async () => {
-      const toggled: DriftSchedule = {
-        id: 99,
-        name: 'Test',
-        checkInterval: '2h',
-        enabled: true,
-        createdAt: '2023-01-01T00:00:00Z',
-        updatedAt: '2023-01-01T00:00:00Z'
-      }
-      ;(api.post as any).mockResolvedValue({
-        data: { success: true, data: toggled, timestamp: new Date().toISOString() }
-      })
-
-      const result = await toggleDriftSchedule('99')
-
-      expect(result).toEqual(toggled)
-      expect(api.post).toHaveBeenCalledWith('/config/drift-schedules/99/toggle')
-    })
-
-    it('throws error when toggle fails', async () => {
-      ;(api.post as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Schedule locked', code: 'LOCKED' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(toggleDriftSchedule(1)).rejects.toThrow('Schedule locked')
+      expect(api.post).toHaveBeenCalledWith('/config/drift-schedules/1/toggle', {})
+      expect(result.enabled).toBe(false)
     })
   })
 
   describe('getDriftScheduleRuns', () => {
-    it('returns schedule run history with default pagination', async () => {
-      const runs: DriftScheduleRun[] = [
-        {
-          id: 1,
-          scheduleId: 1,
-          startedAt: '2023-01-01T00:00:00Z',
-          completedAt: '2023-01-01T00:05:00Z',
-          status: 'completed',
-          devicesChecked: 10,
-          driftsDetected: 2
-        }
-      ]
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { runs },
-          meta: { total: 1, page: 1, pageSize: 25 },
-          timestamp: new Date().toISOString()
-        }
-      })
+    it('returns raw array unwrapped', async () => {
+      const runs: DriftScheduleRun[] = [{
+        id: 1, schedule_id: 1, status: 'completed',
+        started_at: 'x', completed_at: 'y', created_at: 'x'
+      }]
+      vi.mocked(api.get).mockResolvedValueOnce(ok(runs))
 
-      const result = await getDriftScheduleRuns(1)
+      const result = await getDriftScheduleRuns(1, 10)
 
-      expect(result.items).toEqual(runs)
-      expect(result.meta).toEqual({ total: 1, page: 1, pageSize: 25 })
       expect(api.get).toHaveBeenCalledWith('/config/drift-schedules/1/runs', {
-        params: { page: 1, page_size: 25 }
+        params: { limit: 10 }
       })
-    })
-
-    it('returns runs with custom pagination', async () => {
-      const runs: DriftScheduleRun[] = []
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { runs },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      const result = await getDriftScheduleRuns('42', 3, 10)
-
-      expect(result.items).toEqual([])
-      expect(api.get).toHaveBeenCalledWith('/config/drift-schedules/42/runs', {
-        params: { page: 3, page_size: 10 }
-      })
-    })
-
-    it('throws error when request fails', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Schedule not found', code: 'NOT_FOUND' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(getDriftScheduleRuns(999)).rejects.toThrow('Schedule not found')
+      expect(result.items).toEqual(runs)
     })
   })
 
   describe('getDriftReports', () => {
-    it('returns drift reports with default parameters', async () => {
-      const reports: DriftReport[] = [
-        {
-          id: 1,
-          deviceId: 1,
-          deviceName: 'Device 1',
-          detectedAt: '2023-01-01T00:00:00Z',
-          driftType: 'config_changed',
-          field: 'wifi.ssid',
-          expectedValue: 'OldSSID',
-          actualValue: 'NewSSID',
-          severity: 'medium',
-          resolved: false
-        }
-      ]
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { reports },
-          meta: { total: 1, page: 1, pageSize: 25 },
-          timestamp: new Date().toISOString()
-        }
-      })
+    it('returns raw array of aggregate reports', async () => {
+      const reports: DriftReport[] = [{
+        id: 1, report_type: 'device', device_id: 5,
+        summary: { total_devices: 1 }, devices: [], recommendations: [],
+        generated_at: 'x', created_at: 'x'
+      }]
+      vi.mocked(api.get).mockResolvedValueOnce(ok(reports))
 
-      const result = await getDriftReports()
+      const result = await getDriftReports(50, 5, 'device')
 
-      expect(result.items).toEqual(reports)
-      expect(result.meta).toEqual({ total: 1, page: 1, pageSize: 25 })
       expect(api.get).toHaveBeenCalledWith('/config/drift-reports', {
-        params: { page: 1, page_size: 25, resolved: undefined }
+        params: { limit: 50, device_id: 5, type: 'device' }
       })
-    })
-
-    it('filters by resolved status', async () => {
-      const reports: DriftReport[] = []
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { reports },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      const result = await getDriftReports(2, 50, true)
-
-      expect(result.items).toEqual([])
-      expect(api.get).toHaveBeenCalledWith('/config/drift-reports', {
-        params: { page: 2, page_size: 50, resolved: true }
-      })
-    })
-
-    it('throws error when request fails', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Database error', code: 'DB_ERROR' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(getDriftReports()).rejects.toThrow('Database error')
+      expect(result).toEqual(reports)
     })
   })
 
   describe('getDriftTrends', () => {
-    it('returns drift trends with default days', async () => {
-      const trends: DriftTrend[] = [
-        {
-          date: '2023-01-01',
-          totalDrifts: 10,
-          resolvedDrifts: 8,
-          unresolvedDrifts: 2,
-          deviceCount: 5
-        }
-      ]
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { trends },
-          timestamp: new Date().toISOString()
-        }
-      })
+    it('returns raw array of per-path trends', async () => {
+      const trends: DriftTrend[] = [{
+        id: 1, device_id: 5, path: 'wifi.ssid', category: 'network', severity: 'info',
+        first_seen: '2026-04-10T00:00:00Z', last_seen: '2026-04-13T00:00:00Z',
+        occurrences: 3, resolved: false, created_at: 'x', updated_at: 'x'
+      }]
+      vi.mocked(api.get).mockResolvedValueOnce(ok(trends))
 
-      const result = await getDriftTrends()
+      const result = await getDriftTrends(200, false, 5)
 
-      expect(result).toEqual(trends)
       expect(api.get).toHaveBeenCalledWith('/config/drift-trends', {
-        params: { days: 30 }
+        params: { limit: 200, resolved: false, device_id: 5 }
       })
-    })
-
-    it('returns trends with custom days', async () => {
-      const trends: DriftTrend[] = []
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { trends },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      const result = await getDriftTrends(7)
-
-      expect(result).toEqual([])
-      expect(api.get).toHaveBeenCalledWith('/config/drift-trends', {
-        params: { days: 7 }
-      })
-    })
-
-    it('throws error when request fails', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Invalid days parameter', code: 'VALIDATION_ERROR' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(getDriftTrends(0)).rejects.toThrow('Invalid days parameter')
-    })
-
-    it('throws default error when data is missing', async () => {
-      ;(api.get as any).mockResolvedValue({
-        data: { success: true, timestamp: new Date().toISOString() }
-      })
-
-      await expect(getDriftTrends()).rejects.toThrow('Failed to load drift trends')
+      expect(result[0].path).toBe('wifi.ssid')
     })
   })
 
-  describe('resolveDriftReport', () => {
-    it('resolves a drift report without notes', async () => {
-      const resolved: DriftReport = {
-        id: 1,
-        deviceId: 1,
-        deviceName: 'Device 1',
-        detectedAt: '2023-01-01T00:00:00Z',
-        driftType: 'config_changed',
-        field: 'wifi.ssid',
-        expectedValue: 'OldSSID',
-        actualValue: 'NewSSID',
-        severity: 'medium',
-        resolved: true,
-        resolvedAt: '2023-01-02T00:00:00Z',
-        resolvedBy: 'admin'
-      }
-      ;(api.post as any).mockResolvedValue({
-        data: { success: true, data: resolved, timestamp: new Date().toISOString() }
-      })
-
-      const result = await resolveDriftReport(1)
-
-      expect(result).toEqual(resolved)
-      expect(api.post).toHaveBeenCalledWith('/config/drift-trends/1/resolve', { notes: undefined })
+  describe('resolveDriftTrend', () => {
+    it('posts to drift-trends/{id}/resolve with empty body for Content-Type middleware', async () => {
+      vi.mocked(api.post).mockResolvedValueOnce(ok({ status: 'resolved' }))
+      await resolveDriftTrend(42)
+      expect(api.post).toHaveBeenCalledWith('/config/drift-trends/42/resolve', {})
     })
 
-    it('resolves a drift report with notes', async () => {
-      const resolved: DriftReport = {
-        id: 2,
-        deviceId: 2,
-        deviceName: 'Device 2',
-        detectedAt: '2023-01-01T00:00:00Z',
-        driftType: 'unexpected_value',
-        field: 'power.default',
-        expectedValue: 'off',
-        actualValue: 'on',
-        severity: 'high',
-        resolved: true,
-        resolvedAt: '2023-01-02T00:00:00Z',
-        resolvedBy: 'admin',
-        notes: 'Fixed manually'
-      }
-      ;(api.post as any).mockResolvedValue({
-        data: { success: true, data: resolved, timestamp: new Date().toISOString() }
-      })
-
-      const result = await resolveDriftReport('2', 'Fixed manually')
-
-      expect(result).toEqual(resolved)
-      expect(api.post).toHaveBeenCalledWith('/config/drift-trends/2/resolve', {
-        notes: 'Fixed manually'
-      })
-    })
-
-    it('throws error when resolution fails', async () => {
-      ;(api.post as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Report not found', code: 'NOT_FOUND' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(resolveDriftReport(999)).rejects.toThrow('Report not found')
+    it('throws on failure', async () => {
+      vi.mocked(api.post).mockResolvedValueOnce(fail('not found'))
+      await expect(resolveDriftTrend(99)).rejects.toThrow('not found')
     })
   })
 
   describe('generateDeviceDriftReport', () => {
-    it('generates drift report for a device', async () => {
-      const reports: DriftReport[] = [
-        {
-          id: 1,
-          deviceId: 1,
-          deviceName: 'Device 1',
-          detectedAt: '2023-01-01T00:00:00Z',
-          driftType: 'config_changed',
-          field: 'wifi.ssid',
-          expectedValue: 'OldSSID',
-          actualValue: 'NewSSID',
-          severity: 'medium',
-          resolved: false
-        },
-        {
-          id: 2,
-          deviceId: 1,
-          deviceName: 'Device 1',
-          detectedAt: '2023-01-01T00:00:00Z',
-          driftType: 'missing_config',
-          field: 'power.schedule',
-          expectedValue: '{"enabled":true}',
-          actualValue: null,
-          severity: 'low',
-          resolved: false
-        }
+    it('posts and returns single aggregate report', async () => {
+      const report: DriftReport = {
+        id: 10, report_type: 'device', device_id: 5,
+        summary: {}, devices: [], recommendations: [],
+        generated_at: 'x', created_at: 'x'
+      }
+      vi.mocked(api.post).mockResolvedValueOnce(ok(report))
+
+      const result = await generateDeviceDriftReport(5)
+
+      expect(api.post).toHaveBeenCalledWith('/devices/5/drift-report', {})
+      expect(result.id).toBe(10)
+    })
+  })
+
+  describe('computeDailyAggregates', () => {
+    const now = new Date('2026-04-13T12:00:00Z')
+    beforeEach(() => vi.setSystemTime(now))
+
+    it('buckets by last_seen date and counts resolved/unresolved', () => {
+      const trends: DriftTrend[] = [
+        { id: 1, device_id: 1, path: 'a', category: 'x', severity: 'low',
+          first_seen: '2026-04-12T00:00:00Z', last_seen: '2026-04-12T09:00:00Z',
+          occurrences: 1, resolved: false, created_at: 'x', updated_at: 'x' },
+        { id: 2, device_id: 2, path: 'b', category: 'x', severity: 'high',
+          first_seen: '2026-04-12T00:00:00Z', last_seen: '2026-04-12T10:00:00Z',
+          occurrences: 2, resolved: true, resolved_at: '2026-04-12T11:00:00Z',
+          created_at: 'x', updated_at: 'x' },
+        { id: 3, device_id: 1, path: 'c', category: 'x', severity: 'medium',
+          first_seen: '2026-04-13T00:00:00Z', last_seen: '2026-04-13T11:00:00Z',
+          occurrences: 5, resolved: false, created_at: 'x', updated_at: 'x' }
       ]
-      ;(api.post as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { reports },
-          timestamp: new Date().toISOString()
-        }
+
+      const result = computeDailyAggregates(trends, 7)
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({
+        date: '2026-04-12',
+        totalDrifts: 2,
+        resolvedDrifts: 1,
+        unresolvedDrifts: 1,
+        deviceCount: 2
       })
-
-      const result = await generateDeviceDriftReport(1)
-
-      expect(result).toEqual(reports)
-      expect(api.post).toHaveBeenCalledWith('/devices/1/drift-report')
+      expect(result[1]).toEqual({
+        date: '2026-04-13',
+        totalDrifts: 1,
+        resolvedDrifts: 0,
+        unresolvedDrifts: 1,
+        deviceCount: 1
+      })
     })
 
-    it('accepts string device ID', async () => {
-      const reports: DriftReport[] = []
-      ;(api.post as any).mockResolvedValue({
-        data: {
-          success: true,
-          data: { reports },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      const result = await generateDeviceDriftReport('42')
-
-      expect(result).toEqual([])
-      expect(api.post).toHaveBeenCalledWith('/devices/42/drift-report')
+    it('drops trends outside the cutoff window', () => {
+      const trends: DriftTrend[] = [
+        { id: 1, device_id: 1, path: 'old', category: 'x', severity: 'low',
+          first_seen: '2026-01-01T00:00:00Z', last_seen: '2026-01-01T00:00:00Z',
+          occurrences: 1, resolved: false, created_at: 'x', updated_at: 'x' },
+        { id: 2, device_id: 1, path: 'new', category: 'x', severity: 'low',
+          first_seen: '2026-04-13T00:00:00Z', last_seen: '2026-04-13T00:00:00Z',
+          occurrences: 1, resolved: false, created_at: 'x', updated_at: 'x' }
+      ]
+      const result = computeDailyAggregates(trends, 7)
+      expect(result.map(r => r.date)).toEqual(['2026-04-13'])
     })
 
-    it('throws error when generation fails', async () => {
-      ;(api.post as any).mockResolvedValue({
-        data: {
-          success: false,
-          error: { message: 'Device offline', code: 'DEVICE_OFFLINE' },
-          timestamp: new Date().toISOString()
-        }
-      })
-
-      await expect(generateDeviceDriftReport(1)).rejects.toThrow('Device offline')
-    })
-
-    it('throws default error when data is missing', async () => {
-      ;(api.post as any).mockResolvedValue({
-        data: { success: true, timestamp: new Date().toISOString() }
-      })
-
-      await expect(generateDeviceDriftReport(1)).rejects.toThrow(
-        'Failed to generate device drift report'
-      )
+    it('returns empty array when trends list is empty', () => {
+      expect(computeDailyAggregates([], 30)).toEqual([])
     })
   })
 })

--- a/ui/src/api/drift.ts
+++ b/ui/src/api/drift.ts
@@ -1,49 +1,71 @@
 import api from './client'
 import type { APIResponse, Metadata } from './types'
 
-// Drift detection interfaces
+// Backend uses snake_case; these interfaces mirror `internal/configuration/models.go`.
+
 export interface DriftSchedule {
   id: number
   name: string
   description?: string
-  deviceIds?: number[]
-  deviceFilter?: string
-  checkInterval: string // e.g., "1h", "24h"
   enabled: boolean
-  lastRun?: string
-  nextRun?: string
-  createdAt: string
-  updatedAt: string
+  cron_spec: string
+  device_ids?: number[] | null
+  device_filter?: string | null
+  last_run?: string | null
+  next_run?: string | null
+  run_count: number
+  created_at: string
+  updated_at: string
 }
 
 export interface DriftScheduleRun {
   id: number
-  scheduleId: number
-  startedAt: string
-  completedAt?: string
-  status: 'pending' | 'running' | 'completed' | 'failed'
-  devicesChecked: number
-  driftsDetected: number
+  schedule_id: number
+  status: 'running' | 'completed' | 'failed'
+  started_at: string
+  completed_at?: string | null
+  duration?: number | null
+  results?: string
   error?: string
+  created_at: string
 }
 
+// Aggregate report (summary + devices + recommendations). Backend model;
+// the UI currently does not render these directly — see DriftTrend for
+// per-path drift items shown on the "Drift Reports" page.
 export interface DriftReport {
   id: number
-  deviceId: number
-  deviceName: string
-  detectedAt: string
-  driftType: 'config_changed' | 'unexpected_value' | 'missing_config'
-  field: string
-  expectedValue: any
-  actualValue: any
-  severity: 'low' | 'medium' | 'high' | 'critical'
-  resolved: boolean
-  resolvedAt?: string
-  resolvedBy?: string
-  notes?: string
+  report_type: string
+  device_id?: number | null
+  schedule_id?: number | null
+  summary: Record<string, unknown>
+  devices: Array<Record<string, unknown>>
+  recommendations: Array<Record<string, unknown>>
+  generated_at: string
+  created_at: string
 }
 
+// Per-path drift pattern tracked over time. Backend entity backing the
+// UI's "Drift Reports" table (one row per drifting config path per device)
+// and resolvable via POST /config/drift-trends/{id}/resolve.
 export interface DriftTrend {
+  id: number
+  device_id: number
+  path: string
+  category: string
+  severity: 'low' | 'medium' | 'high' | 'critical' | string
+  first_seen: string
+  last_seen: string
+  occurrences: number
+  resolved: boolean
+  resolved_at?: string | null
+  created_at: string
+  updated_at: string
+}
+
+// Daily aggregate derived client-side from a list of DriftTrend records;
+// fuels the "Drift Trends" chart page. Backend has no equivalent endpoint.
+export interface DriftDailyAggregate {
   date: string
   totalDrifts: number
   resolvedDrifts: number
@@ -54,10 +76,10 @@ export interface DriftTrend {
 export interface CreateDriftScheduleRequest {
   name: string
   description?: string
-  deviceIds?: number[]
-  deviceFilter?: string
-  checkInterval: string
   enabled?: boolean
+  cron_spec: string
+  device_ids?: number[]
+  device_filter?: string
 }
 
 export interface ListDriftSchedulesResult {
@@ -65,14 +87,9 @@ export interface ListDriftSchedulesResult {
   meta?: Metadata
 }
 
-export interface ListDriftReportsResult {
-  items: DriftReport[]
-  meta?: Metadata
-}
-
-// List drift schedules
+// List drift schedules. Backend returns a raw array at `data`.
 export async function listDriftSchedules(page = 1, pageSize = 25): Promise<ListDriftSchedulesResult> {
-  const res = await api.get<APIResponse<{ schedules: DriftSchedule[] }>>('/config/drift-schedules', {
+  const res = await api.get<APIResponse<DriftSchedule[]>>('/config/drift-schedules', {
     params: { page, page_size: pageSize }
   })
   if (!res.data.success) {
@@ -80,12 +97,11 @@ export async function listDriftSchedules(page = 1, pageSize = 25): Promise<ListD
     throw new Error(msg)
   }
   return {
-    items: res.data.data?.schedules || [],
+    items: res.data.data || [],
     meta: res.data.meta
   }
 }
 
-// Get single drift schedule
 export async function getDriftSchedule(id: number | string): Promise<DriftSchedule> {
   const res = await api.get<APIResponse<DriftSchedule>>(`/config/drift-schedules/${id}`)
   if (!res.data.success || !res.data.data) {
@@ -95,7 +111,6 @@ export async function getDriftSchedule(id: number | string): Promise<DriftSchedu
   return res.data.data
 }
 
-// Create drift schedule
 export async function createDriftSchedule(data: CreateDriftScheduleRequest): Promise<DriftSchedule> {
   const res = await api.post<APIResponse<DriftSchedule>>('/config/drift-schedules', data)
   if (!res.data.success || !res.data.data) {
@@ -105,7 +120,6 @@ export async function createDriftSchedule(data: CreateDriftScheduleRequest): Pro
   return res.data.data
 }
 
-// Update drift schedule
 export async function updateDriftSchedule(id: number | string, data: Partial<CreateDriftScheduleRequest>): Promise<DriftSchedule> {
   const res = await api.put<APIResponse<DriftSchedule>>(`/config/drift-schedules/${id}`, data)
   if (!res.data.success || !res.data.data) {
@@ -115,7 +129,6 @@ export async function updateDriftSchedule(id: number | string, data: Partial<Cre
   return res.data.data
 }
 
-// Delete drift schedule
 export async function deleteDriftSchedule(id: number | string): Promise<void> {
   const res = await api.delete<APIResponse<void>>(`/config/drift-schedules/${id}`)
   if (!res.data.success) {
@@ -124,9 +137,10 @@ export async function deleteDriftSchedule(id: number | string): Promise<void> {
   }
 }
 
-// Toggle drift schedule enabled status
 export async function toggleDriftSchedule(id: number | string): Promise<DriftSchedule> {
-  const res = await api.post<APIResponse<DriftSchedule>>(`/config/drift-schedules/${id}/toggle`)
+  // Empty-body POST: pass {} so axios emits a Content-Type header
+  // (required by the backend's ValidateContentTypeMiddleware).
+  const res = await api.post<APIResponse<DriftSchedule>>(`/config/drift-schedules/${id}/toggle`, {})
   if (!res.data.success || !res.data.data) {
     const msg = res.data.error?.message || 'Failed to toggle drift schedule'
     throw new Error(msg)
@@ -134,64 +148,99 @@ export async function toggleDriftSchedule(id: number | string): Promise<DriftSch
   return res.data.data
 }
 
-// Get drift schedule run history
-export async function getDriftScheduleRuns(id: number | string, page = 1, pageSize = 25): Promise<{ items: DriftScheduleRun[]; meta?: Metadata }> {
-  const res = await api.get<APIResponse<{ runs: DriftScheduleRun[] }>>(`/config/drift-schedules/${id}/runs`, {
-    params: { page, page_size: pageSize }
+// Backend returns a raw array; `limit` is the only filter the handler reads.
+export async function getDriftScheduleRuns(id: number | string, limit = 50): Promise<{ items: DriftScheduleRun[]; meta?: Metadata }> {
+  const res = await api.get<APIResponse<DriftScheduleRun[]>>(`/config/drift-schedules/${id}/runs`, {
+    params: { limit }
   })
   if (!res.data.success) {
     const msg = res.data.error?.message || 'Failed to load schedule runs'
     throw new Error(msg)
   }
   return {
-    items: res.data.data?.runs || [],
+    items: res.data.data || [],
     meta: res.data.meta
   }
 }
 
-// Get drift reports
-export async function getDriftReports(page = 1, pageSize = 25, resolved?: boolean): Promise<ListDriftReportsResult> {
-  const res = await api.get<APIResponse<{ reports: DriftReport[] }>>('/config/drift-reports', {
-    params: { page, page_size: pageSize, resolved }
+// Aggregate drift reports. Returned as a raw array. Rarely used by the UI today;
+// the Drift Reports page now renders DriftTrend rows (via getDriftTrends).
+export async function getDriftReports(limit = 50, deviceId?: number, reportType?: string): Promise<DriftReport[]> {
+  const res = await api.get<APIResponse<DriftReport[]>>('/config/drift-reports', {
+    params: { limit, device_id: deviceId, type: reportType }
   })
   if (!res.data.success) {
     const msg = res.data.error?.message || 'Failed to load drift reports'
     throw new Error(msg)
   }
-  return {
-    items: res.data.data?.reports || [],
-    meta: res.data.meta
-  }
+  return res.data.data || []
 }
 
-// Get drift trends
-export async function getDriftTrends(days = 30): Promise<DriftTrend[]> {
-  const res = await api.get<APIResponse<{ trends: DriftTrend[] }>>('/config/drift-trends', {
-    params: { days }
+// Per-path drift patterns. Backend returns a raw array; filters are
+// `device_id`, `resolved`, `limit`. There is no `days` filter on the server —
+// the caller passes `limit` and derives date-range views client-side.
+export async function getDriftTrends(limit = 500, resolved?: boolean, deviceId?: number): Promise<DriftTrend[]> {
+  const res = await api.get<APIResponse<DriftTrend[]>>('/config/drift-trends', {
+    params: { limit, resolved, device_id: deviceId }
   })
-  if (!res.data.success || !res.data.data) {
+  if (!res.data.success) {
     const msg = res.data.error?.message || 'Failed to load drift trends'
     throw new Error(msg)
   }
-  return res.data.data.trends || []
+  return res.data.data || []
 }
 
-// Resolve drift report
-export async function resolveDriftReport(id: number | string, notes?: string): Promise<DriftReport> {
-  const res = await api.post<APIResponse<DriftReport>>(`/config/drift-trends/${id}/resolve`, { notes })
+// Mark a DriftTrend (per-path pattern) as resolved. The backend handler
+// ignores the request body but the Content-Type middleware still requires
+// a JSON payload, so we send {}.
+export async function resolveDriftTrend(id: number | string): Promise<void> {
+  const res = await api.post<APIResponse<{ status: string }>>(`/config/drift-trends/${id}/resolve`, {})
+  if (!res.data.success) {
+    const msg = res.data.error?.message || 'Failed to resolve drift trend'
+    throw new Error(msg)
+  }
+}
+
+export async function generateDeviceDriftReport(deviceId: number | string): Promise<DriftReport> {
+  const res = await api.post<APIResponse<DriftReport>>(`/devices/${deviceId}/drift-report`, {})
   if (!res.data.success || !res.data.data) {
-    const msg = res.data.error?.message || 'Failed to resolve drift report'
+    const msg = res.data.error?.message || 'Failed to generate device drift report'
     throw new Error(msg)
   }
   return res.data.data
 }
 
-// Generate drift report for a device
-export async function generateDeviceDriftReport(deviceId: number | string): Promise<DriftReport[]> {
-  const res = await api.post<APIResponse<{ reports: DriftReport[] }>>(`/devices/${deviceId}/drift-report`)
-  if (!res.data.success || !res.data.data) {
-    const msg = res.data.error?.message || 'Failed to generate device drift report'
-    throw new Error(msg)
+// Compute day-bucketed drift totals from per-path trend records. Each trend
+// contributes to the day in which it was last seen; resolution counts use
+// resolved_at when present, otherwise last_seen.
+export function computeDailyAggregates(trends: DriftTrend[], days = 30): DriftDailyAggregate[] {
+  const bucket = new Map<string, { total: number; resolved: number; unresolved: number; devices: Set<number> }>()
+  const cutoff = Date.now() - days * 86_400_000
+
+  for (const t of trends) {
+    const basis = t.resolved && t.resolved_at ? t.resolved_at : t.last_seen
+    const time = new Date(basis).getTime()
+    if (!Number.isFinite(time) || time < cutoff) continue
+
+    const date = basis.slice(0, 10)
+    let entry = bucket.get(date)
+    if (!entry) {
+      entry = { total: 0, resolved: 0, unresolved: 0, devices: new Set<number>() }
+      bucket.set(date, entry)
+    }
+    entry.total += 1
+    if (t.resolved) entry.resolved += 1
+    else entry.unresolved += 1
+    entry.devices.add(t.device_id)
   }
-  return res.data.data.reports || []
+
+  return Array.from(bucket.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, e]) => ({
+      date,
+      totalDrifts: e.total,
+      resolvedDrifts: e.resolved,
+      unresolvedDrifts: e.unresolved,
+      deviceCount: e.devices.size
+    }))
 }

--- a/ui/src/pages/DriftReportsPage.vue
+++ b/ui/src/pages/DriftReportsPage.vue
@@ -1,22 +1,25 @@
 <template>
   <div class="page">
     <div class="page-header">
-      <h1>Drift Reports</h1>
+      <div>
+        <h1>Drift Reports</h1>
+        <p class="subhead">Per-device, per-path drift items tracked over time.</p>
+      </div>
       <div class="filters">
         <select v-model="resolvedFilter" class="select" @change="handleFilterChange">
-          <option value="">All Reports</option>
+          <option value="">All Items</option>
           <option value="false">Unresolved Only</option>
           <option value="true">Resolved Only</option>
         </select>
       </div>
     </div>
 
-    <div v-if="store.loading" class="loading">Loading reports...</div>
+    <div v-if="store.loading" class="loading">Loading drift items...</div>
     <div v-else-if="store.error" class="error">{{ store.error }}</div>
 
     <div v-else class="content">
-      <div v-if="store.reports.length === 0" class="empty">
-        <p>No drift reports found.</p>
+      <div v-if="store.trends.length === 0" class="empty">
+        <p>No drift items found.</p>
         <p v-if="resolvedFilter">Try adjusting your filters.</p>
       </div>
 
@@ -25,64 +28,59 @@
           <thead>
             <tr>
               <th>Device</th>
-              <th>Field</th>
-              <th>Drift Type</th>
-              <th>Expected</th>
-              <th>Actual</th>
+              <th>Path</th>
+              <th>Category</th>
               <th>Severity</th>
-              <th>Detected</th>
+              <th>First Seen</th>
+              <th>Last Seen</th>
+              <th>Occurrences</th>
               <th>Status</th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
             <tr
-              v-for="report in store.reports"
-              :key="report.id"
-              :class="{ resolved: report.resolved }"
+              v-for="item in store.trends"
+              :key="item.id"
+              :class="{ resolved: item.resolved }"
             >
               <td>
-                <router-link :to="`/devices/${report.deviceId}`" class="device-link">
-                  {{ report.deviceName }}
+                <router-link :to="`/devices/${item.device_id}`" class="device-link">
+                  Device #{{ item.device_id }}
                 </router-link>
               </td>
               <td>
-                <code class="field-name">{{ report.field }}</code>
+                <code class="field-name">{{ item.path }}</code>
               </td>
               <td>
-                <span class="drift-type" :class="report.driftType">
-                  {{ formatDriftType(report.driftType) }}
+                <span class="category-badge">{{ item.category }}</span>
+              </td>
+              <td>
+                <span class="severity-badge" :class="item.severity">
+                  {{ item.severity }}
                 </span>
               </td>
               <td>
-                <code class="value">{{ formatValue(report.expectedValue) }}</code>
+                <span class="timestamp">{{ formatDate(item.first_seen) }}</span>
               </td>
               <td>
-                <code class="value">{{ formatValue(report.actualValue) }}</code>
+                <span class="timestamp">{{ formatDate(item.last_seen) }}</span>
               </td>
+              <td class="numeric">{{ item.occurrences }}</td>
               <td>
-                <span class="severity-badge" :class="report.severity">
-                  {{ report.severity }}
-                </span>
-              </td>
-              <td>
-                <span class="timestamp">{{ formatDate(report.detectedAt) }}</span>
-              </td>
-              <td>
-                <span v-if="report.resolved" class="status-badge resolved">
+                <span v-if="item.resolved" class="status-badge resolved">
                   Resolved
-                  <span v-if="report.resolvedAt" class="resolved-info">
-                    {{ formatDate(report.resolvedAt) }}
-                    <span v-if="report.resolvedBy">by {{ report.resolvedBy }}</span>
+                  <span v-if="item.resolved_at" class="resolved-info">
+                    {{ formatDate(item.resolved_at) }}
                   </span>
                 </span>
                 <span v-else class="status-badge unresolved">Unresolved</span>
               </td>
               <td>
                 <button
-                  v-if="!report.resolved"
+                  v-if="!item.resolved"
                   class="btn-small"
-                  @click="openResolveDialog(report)"
+                  @click="openResolveDialog(item)"
                 >
                   Resolve
                 </button>
@@ -92,71 +90,51 @@
           </tbody>
         </table>
       </div>
-
-      <div v-if="store.reportMeta && store.reportMeta.total > pageSize" class="pagination">
-        <button class="btn" :disabled="page === 1" @click="handlePageChange(page - 1)">
-          Previous
-        </button>
-        <span class="page-info">
-          Page {{ page }} of {{ Math.ceil(store.reportMeta.total / pageSize) }}
-          ({{ store.reportMeta.total }} total)
-        </span>
-        <button
-          class="btn"
-          :disabled="page >= Math.ceil(store.reportMeta.total / pageSize)"
-          @click="handlePageChange(page + 1)"
-        >
-          Next
-        </button>
-      </div>
     </div>
 
-    <!-- Resolve Dialog -->
-    <div v-if="resolvingReport" class="modal" @click.self="closeResolveDialog">
+    <div v-if="resolvingItem" class="modal" @click.self="closeResolveDialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Resolve Drift Report</h2>
+          <h2>Resolve Drift Item</h2>
           <button class="btn-close" @click="closeResolveDialog">×</button>
         </div>
 
         <div class="report-summary">
           <div class="summary-item">
             <span class="label">Device:</span>
-            <span class="value">{{ resolvingReport.deviceName }}</span>
+            <span class="value">#{{ resolvingItem.device_id }}</span>
           </div>
           <div class="summary-item">
-            <span class="label">Field:</span>
-            <code class="value">{{ resolvingReport.field }}</code>
+            <span class="label">Path:</span>
+            <code class="value">{{ resolvingItem.path }}</code>
           </div>
           <div class="summary-item">
-            <span class="label">Drift Type:</span>
-            <span class="value">{{ formatDriftType(resolvingReport.driftType) }}</span>
+            <span class="label">Category:</span>
+            <span class="value">{{ resolvingItem.category }}</span>
           </div>
           <div class="summary-item">
             <span class="label">Severity:</span>
-            <span class="severity-badge" :class="resolvingReport.severity">
-              {{ resolvingReport.severity }}
+            <span class="severity-badge" :class="resolvingItem.severity">
+              {{ resolvingItem.severity }}
             </span>
+          </div>
+          <div class="summary-item">
+            <span class="label">Occurrences:</span>
+            <span class="value">{{ resolvingItem.occurrences }}</span>
           </div>
         </div>
 
-        <form @submit.prevent="handleResolve">
-          <div class="form-field">
-            <label for="notes">Resolution Notes</label>
-            <textarea
-              id="notes"
-              v-model="resolveNotes"
-              class="form-textarea"
-              rows="4"
-              placeholder="Optional: Add notes about how this drift was resolved..."
-            />
-          </div>
+        <p class="resolution-note">
+          Marking this drift pattern as resolved clears it from the unresolved list.
+          The backend does not persist resolution notes.
+        </p>
 
-          <div class="form-actions">
-            <button type="button" class="btn" @click="closeResolveDialog">Cancel</button>
-            <button type="submit" class="btn primary">Mark as Resolved</button>
-          </div>
-        </form>
+        <div class="form-actions">
+          <button type="button" class="btn" @click="closeResolveDialog">Cancel</button>
+          <button type="button" class="btn primary" @click="handleResolve">
+            Mark as Resolved
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -165,15 +143,12 @@
 <script setup lang="ts">
 import { ref, onMounted, computed } from 'vue'
 import { useDriftStore } from '@/stores/drift'
-import type { DriftReport } from '@/api/drift'
+import type { DriftTrend } from '@/api/drift'
 
 const store = useDriftStore()
 
-const page = ref(1)
-const pageSize = ref(25)
 const resolvedFilter = ref('')
-const resolvingReport = ref<DriftReport | null>(null)
-const resolveNotes = ref('')
+const resolvingItem = ref<DriftTrend | null>(null)
 
 const resolvedBoolean = computed<boolean | undefined>(() => {
   if (resolvedFilter.value === 'true') return true
@@ -181,58 +156,35 @@ const resolvedBoolean = computed<boolean | undefined>(() => {
   return undefined
 })
 
-function formatDate(dateStr: string): string {
+function formatDate(dateStr?: string | null): string {
+  if (!dateStr) return '—'
   return new Date(dateStr).toLocaleString()
 }
 
-function formatDriftType(type: string): string {
-  return type
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, l => l.toUpperCase())
-}
-
-function formatValue(value: any): string {
-  if (value === null || value === undefined) return 'null'
-  if (typeof value === 'object') return JSON.stringify(value)
-  return String(value)
-}
-
-function openResolveDialog(report: DriftReport) {
-  resolvingReport.value = report
-  resolveNotes.value = report.notes || ''
+function openResolveDialog(item: DriftTrend) {
+  resolvingItem.value = item
 }
 
 function closeResolveDialog() {
-  resolvingReport.value = null
-  resolveNotes.value = ''
+  resolvingItem.value = null
 }
 
 async function handleResolve() {
-  if (!resolvingReport.value) return
-
+  if (!resolvingItem.value) return
   try {
-    await store.resolveReport(
-      resolvingReport.value.id,
-      resolveNotes.value.trim() || undefined
-    )
+    await store.resolveTrend(resolvingItem.value.id)
     closeResolveDialog()
   } catch (e: any) {
-    alert(e?.message || 'Failed to resolve report')
+    alert(e?.message || 'Failed to resolve drift item')
   }
 }
 
 async function handleFilterChange() {
-  page.value = 1
-  await store.fetchReports(page.value, pageSize.value, resolvedBoolean.value)
-}
-
-async function handlePageChange(newPage: number) {
-  page.value = newPage
-  await store.fetchReports(page.value, pageSize.value, resolvedBoolean.value)
+  await store.fetchTrends(resolvedBoolean.value)
 }
 
 onMounted(() => {
-  store.fetchReports(page.value, pageSize.value, resolvedBoolean.value)
+  store.fetchTrends(resolvedBoolean.value)
 })
 </script>
 
@@ -246,12 +198,19 @@ onMounted(() => {
   align-items: center;
   justify-content: space-between;
   margin-bottom: 24px;
+  gap: 16px;
 }
 
 .page-header h1 {
   margin: 0;
   font-size: 24px;
   color: #1f2937;
+}
+
+.subhead {
+  margin: 4px 0 0 0;
+  font-size: 13px;
+  color: #64748b;
 }
 
 .filters {
@@ -317,6 +276,11 @@ onMounted(() => {
   font-size: 14px;
 }
 
+.reports-table td.numeric {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
 .reports-table tbody tr:hover {
   background: #f9fafb;
 }
@@ -343,26 +307,13 @@ onMounted(() => {
   font-size: 13px;
 }
 
-.drift-type {
-  padding: 4px 8px;
+.category-badge {
+  padding: 2px 8px;
+  background: #e0e7ff;
+  color: #3730a3;
   border-radius: 4px;
   font-size: 12px;
   font-weight: 500;
-}
-
-.drift-type.config_changed {
-  background: #dbeafe;
-  color: #1e40af;
-}
-
-.drift-type.unexpected_value {
-  background: #fef3c7;
-  color: #92400e;
-}
-
-.drift-type.missing_config {
-  background: #fee2e2;
-  color: #991b1b;
 }
 
 .value {
@@ -386,7 +337,8 @@ onMounted(() => {
   color: #1e40af;
 }
 
-.severity-badge.medium {
+.severity-badge.medium,
+.severity-badge.warning {
   background: #fef3c7;
   color: #92400e;
 }
@@ -449,19 +401,6 @@ onMounted(() => {
   font-weight: bold;
 }
 
-.pagination {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 16px;
-  margin-top: 24px;
-}
-
-.page-info {
-  font-size: 14px;
-  color: #64748b;
-}
-
 .btn {
   padding: 8px 16px;
   border: 1px solid #cbd5e1;
@@ -473,11 +412,6 @@ onMounted(() => {
 
 .btn:hover {
   background: #f8fafc;
-}
-
-.btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }
 
 .btn.primary {
@@ -545,7 +479,7 @@ onMounted(() => {
   padding: 16px;
   background: #f9fafb;
   border-radius: 6px;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
 .summary-item {
@@ -558,7 +492,7 @@ onMounted(() => {
   font-size: 13px;
   font-weight: 600;
   color: #6b7280;
-  min-width: 80px;
+  min-width: 90px;
 }
 
 .summary-item .value {
@@ -566,26 +500,14 @@ onMounted(() => {
   color: #1f2937;
 }
 
-.form-field {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
+.resolution-note {
+  font-size: 13px;
+  color: #6b7280;
+  padding: 12px;
+  background: #f9fafb;
+  border-left: 3px solid #cbd5e1;
+  border-radius: 4px;
   margin-bottom: 16px;
-}
-
-.form-field label {
-  font-size: 14px;
-  font-weight: 500;
-  color: #374151;
-}
-
-.form-textarea {
-  padding: 8px 12px;
-  border: 1px solid #d1d5db;
-  border-radius: 6px;
-  font-family: inherit;
-  font-size: 14px;
-  resize: vertical;
 }
 
 .form-actions {

--- a/ui/src/pages/DriftSchedulesPage.vue
+++ b/ui/src/pages/DriftSchedulesPage.vue
@@ -35,24 +35,28 @@
 
           <div class="schedule-details">
             <div class="detail-item">
-              <span class="label">Check Interval:</span>
-              <span class="value">{{ schedule.checkInterval }}</span>
+              <span class="label">Cron Schedule:</span>
+              <span class="value"><code>{{ schedule.cron_spec }}</code></span>
             </div>
-            <div v-if="schedule.deviceIds && schedule.deviceIds.length > 0" class="detail-item">
+            <div v-if="schedule.device_ids && schedule.device_ids.length > 0" class="detail-item">
               <span class="label">Devices:</span>
-              <span class="value">{{ schedule.deviceIds.length }} device(s)</span>
+              <span class="value">{{ schedule.device_ids.length }} device(s)</span>
             </div>
-            <div v-if="schedule.deviceFilter" class="detail-item">
+            <div v-if="schedule.device_filter" class="detail-item">
               <span class="label">Device Filter:</span>
-              <span class="value">{{ schedule.deviceFilter }}</span>
+              <span class="value">{{ schedule.device_filter }}</span>
             </div>
-            <div v-if="schedule.lastRun" class="detail-item">
+            <div class="detail-item">
+              <span class="label">Run Count:</span>
+              <span class="value">{{ schedule.run_count }}</span>
+            </div>
+            <div v-if="schedule.last_run" class="detail-item">
               <span class="label">Last Run:</span>
-              <span class="value">{{ formatDate(schedule.lastRun) }}</span>
+              <span class="value">{{ formatDate(schedule.last_run) }}</span>
             </div>
-            <div v-if="schedule.nextRun" class="detail-item">
+            <div v-if="schedule.next_run" class="detail-item">
               <span class="label">Next Run:</span>
-              <span class="value">{{ formatDate(schedule.nextRun) }}</span>
+              <span class="value">{{ formatDate(schedule.next_run) }}</span>
             </div>
           </div>
 
@@ -69,7 +73,7 @@
         </div>
       </div>
 
-      <div v-if="store.scheduleMeta && store.scheduleMeta.total > pageSize" class="pagination">
+      <div v-if="store.scheduleMeta && (store.scheduleMeta.total_count || 0) > pageSize" class="pagination">
         <button
           class="btn"
           :disabled="page === 1"
@@ -78,12 +82,12 @@
           Previous
         </button>
         <span class="page-info">
-          Page {{ page }} of {{ Math.ceil(store.scheduleMeta.total / pageSize) }}
-          ({{ store.scheduleMeta.total }} total)
+          Page {{ page }} of {{ Math.ceil((store.scheduleMeta.total_count || 0) / pageSize) }}
+          ({{ (store.scheduleMeta.total_count || 0) }} total)
         </span>
         <button
           class="btn"
-          :disabled="page >= Math.ceil(store.scheduleMeta.total / pageSize)"
+          :disabled="page >= Math.ceil((store.scheduleMeta.total_count || 0) / pageSize)"
           @click="handlePageChange(page + 1)"
         >
           Next
@@ -121,16 +125,21 @@
           </div>
 
           <div class="form-field">
-            <label for="checkInterval">Check Interval *</label>
+            <label for="cronSpec">Cron Schedule *</label>
             <input
-              id="checkInterval"
-              v-model="formData.checkInterval"
+              id="cronSpec"
+              v-model="formData.cron_spec"
               type="text"
               required
               class="form-input"
-              placeholder="e.g., 1h, 24h, 30m"
+              placeholder="0 */6 * * *"
             />
-            <small>Examples: 1h, 24h, 30m, 7d</small>
+            <small>Standard cron expression. Presets:
+              <button type="button" class="cron-preset" @click="formData.cron_spec = '0 * * * *'">hourly</button>
+              <button type="button" class="cron-preset" @click="formData.cron_spec = '0 */6 * * *'">every 6h</button>
+              <button type="button" class="cron-preset" @click="formData.cron_spec = '0 0 * * *'">daily</button>
+              <button type="button" class="cron-preset" @click="formData.cron_spec = '0 0 * * 0'">weekly</button>
+            </small>
           </div>
 
           <div class="form-field">
@@ -195,9 +204,9 @@ const deviceIdsInput = ref('')
 const formData = ref<CreateDriftScheduleRequest>({
   name: '',
   description: '',
-  checkInterval: '24h',
-  deviceIds: [],
-  deviceFilter: '',
+  cron_spec: '0 0 * * *',
+  device_ids: [],
+  device_filter: '',
   enabled: true
 })
 
@@ -209,9 +218,9 @@ function resetForm() {
   formData.value = {
     name: '',
     description: '',
-    checkInterval: '24h',
-    deviceIds: [],
-    deviceFilter: '',
+    cron_spec: '0 0 * * *',
+    device_ids: [],
+    device_filter: '',
     enabled: true
   }
   deviceIdsInput.value = ''
@@ -222,12 +231,12 @@ function editSchedule(schedule: DriftSchedule) {
   formData.value = {
     name: schedule.name,
     description: schedule.description,
-    checkInterval: schedule.checkInterval,
-    deviceIds: schedule.deviceIds,
-    deviceFilter: schedule.deviceFilter,
+    cron_spec: schedule.cron_spec,
+    device_ids: schedule.device_ids || [],
+    device_filter: schedule.device_filter || '',
     enabled: schedule.enabled
   }
-  deviceIdsInput.value = schedule.deviceIds?.join(',') || ''
+  deviceIdsInput.value = (schedule.device_ids || []).join(',')
 }
 
 function closeDialog() {
@@ -240,12 +249,12 @@ async function handleSubmit() {
   try {
     // Parse device IDs
     if (deviceIdsInput.value.trim()) {
-      formData.value.deviceIds = deviceIdsInput.value
+      formData.value.device_ids = deviceIdsInput.value
         .split(',')
         .map(id => parseInt(id.trim()))
         .filter(id => !isNaN(id))
     } else {
-      formData.value.deviceIds = undefined
+      formData.value.device_ids = undefined
     }
 
     if (editingSchedule.value) {
@@ -554,6 +563,20 @@ onMounted(() => {
 .form-field small {
   font-size: 12px;
   color: #6b7280;
+}
+
+.cron-preset {
+  margin-left: 6px;
+  padding: 2px 6px;
+  font-size: 11px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.cron-preset:hover {
+  background: #e5e7eb;
 }
 
 .form-input,

--- a/ui/src/pages/DriftTrendsPage.vue
+++ b/ui/src/pages/DriftTrendsPage.vue
@@ -17,7 +17,7 @@
     <div v-else-if="store.error" class="error">{{ store.error }}</div>
 
     <div v-else class="content">
-      <div v-if="store.trends.length === 0" class="empty">
+      <div v-if="aggregates.length === 0" class="empty">
         <p>No drift trends data available for the selected period.</p>
       </div>
 
@@ -70,7 +70,7 @@
             <div class="chart-content">
               <div class="chart-bars">
                 <div
-                  v-for="(trend, index) in store.trends"
+                  v-for="(trend, index) in aggregates"
                   :key="index"
                   class="bar-group"
                 >
@@ -124,7 +124,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(trend, index) in store.trends" :key="index">
+              <tr v-for="(trend, index) in aggregates" :key="index">
                 <td>{{ formatDateLong(trend.date) }}</td>
                 <td>{{ trend.totalDrifts }}</td>
                 <td class="resolved-count">{{ trend.resolvedDrifts }}</td>
@@ -157,27 +157,29 @@ import { useDriftStore } from '@/stores/drift'
 const store = useDriftStore()
 const days = ref(30)
 
-const totalDrifts = computed(() => {
-  return store.trends.reduce((sum, t) => sum + t.totalDrifts, 0)
-})
+const aggregates = computed(() => store.trendAggregates)
 
-const totalResolved = computed(() => {
-  return store.trends.reduce((sum, t) => sum + t.resolvedDrifts, 0)
-})
+const totalDrifts = computed(() =>
+  aggregates.value.reduce((sum, t) => sum + t.totalDrifts, 0)
+)
 
-const totalUnresolved = computed(() => {
-  return store.trends.reduce((sum, t) => sum + t.unresolvedDrifts, 0)
-})
+const totalResolved = computed(() =>
+  aggregates.value.reduce((sum, t) => sum + t.resolvedDrifts, 0)
+)
+
+const totalUnresolved = computed(() =>
+  aggregates.value.reduce((sum, t) => sum + t.unresolvedDrifts, 0)
+)
 
 const avgDevices = computed(() => {
-  if (store.trends.length === 0) return 0
-  const total = store.trends.reduce((sum, t) => sum + t.deviceCount, 0)
-  return Math.round(total / store.trends.length)
+  if (aggregates.value.length === 0) return 0
+  const total = aggregates.value.reduce((sum, t) => sum + t.deviceCount, 0)
+  return Math.round(total / aggregates.value.length)
 })
 
-const maxDrifts = computed(() => {
-  return Math.max(...store.trends.map(t => t.totalDrifts), 1)
-})
+const maxDrifts = computed(() =>
+  Math.max(...aggregates.value.map(t => t.totalDrifts), 1)
+)
 
 const yAxisTicks = computed(() => {
   const max = maxDrifts.value
@@ -205,11 +207,13 @@ function formatDateLong(dateStr: string): string {
 }
 
 async function handleDaysChange() {
-  await store.fetchTrends(days.value)
+  store.setTrendAggregateDays(days.value)
+  await store.fetchTrends()
 }
 
 onMounted(() => {
-  store.fetchTrends(days.value)
+  store.setTrendAggregateDays(days.value)
+  store.fetchTrends()
 })
 </script>
 

--- a/ui/src/stores/drift.ts
+++ b/ui/src/stores/drift.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import {
   listDriftSchedules,
@@ -10,30 +10,35 @@ import {
   getDriftScheduleRuns,
   getDriftReports,
   getDriftTrends,
-  resolveDriftReport,
+  resolveDriftTrend,
   generateDeviceDriftReport,
+  computeDailyAggregates,
   type DriftSchedule,
   type DriftScheduleRun,
   type DriftReport,
   type DriftTrend,
+  type DriftDailyAggregate,
   type CreateDriftScheduleRequest
 } from '@/api/drift'
 import type { Metadata } from '@/api/types'
 
 export const useDriftStore = defineStore('drift', () => {
-  // State
   const schedules = ref<DriftSchedule[]>([])
   const currentSchedule = ref<DriftSchedule | null>(null)
   const scheduleRuns = ref<DriftScheduleRun[]>([])
   const reports = ref<DriftReport[]>([])
   const trends = ref<DriftTrend[]>([])
+  const trendAggregateDays = ref(30)
   const loading = ref(false)
   const error = ref<string | null>(null)
   const scheduleMeta = ref<Metadata | undefined>(undefined)
   const reportMeta = ref<Metadata | undefined>(undefined)
   const runsMeta = ref<Metadata | undefined>(undefined)
 
-  // Actions - Drift Schedules
+  const trendAggregates = computed<DriftDailyAggregate[]>(() =>
+    computeDailyAggregates(trends.value, trendAggregateDays.value)
+  )
+
   async function fetchSchedules(page = 1, pageSize = 25) {
     loading.value = true
     error.value = null
@@ -84,12 +89,8 @@ export const useDriftStore = defineStore('drift', () => {
     try {
       const updated = await updateDriftSchedule(id, data)
       const index = schedules.value.findIndex(s => s.id === updated.id)
-      if (index !== -1) {
-        schedules.value[index] = updated
-      }
-      if (currentSchedule.value?.id === updated.id) {
-        currentSchedule.value = updated
-      }
+      if (index !== -1) schedules.value[index] = updated
+      if (currentSchedule.value?.id === updated.id) currentSchedule.value = updated
       return updated
     } catch (e: any) {
       error.value = e?.message || 'Failed to update drift schedule'
@@ -105,9 +106,7 @@ export const useDriftStore = defineStore('drift', () => {
     try {
       await deleteDriftSchedule(id)
       schedules.value = schedules.value.filter(s => s.id !== id)
-      if (currentSchedule.value?.id === id) {
-        currentSchedule.value = null
-      }
+      if (currentSchedule.value?.id === id) currentSchedule.value = null
     } catch (e: any) {
       error.value = e?.message || 'Failed to delete drift schedule'
       throw e
@@ -122,12 +121,8 @@ export const useDriftStore = defineStore('drift', () => {
     try {
       const toggled = await toggleDriftSchedule(id)
       const index = schedules.value.findIndex(s => s.id === toggled.id)
-      if (index !== -1) {
-        schedules.value[index] = toggled
-      }
-      if (currentSchedule.value?.id === toggled.id) {
-        currentSchedule.value = toggled
-      }
+      if (index !== -1) schedules.value[index] = toggled
+      if (currentSchedule.value?.id === toggled.id) currentSchedule.value = toggled
       return toggled
     } catch (e: any) {
       error.value = e?.message || 'Failed to toggle drift schedule'
@@ -137,12 +132,11 @@ export const useDriftStore = defineStore('drift', () => {
     }
   }
 
-  // Actions - Schedule Runs
-  async function fetchScheduleRuns(scheduleId: number | string, page = 1, pageSize = 25) {
+  async function fetchScheduleRuns(scheduleId: number | string, limit = 50) {
     loading.value = true
     error.value = null
     try {
-      const result = await getDriftScheduleRuns(scheduleId, page, pageSize)
+      const result = await getDriftScheduleRuns(scheduleId, limit)
       scheduleRuns.value = result.items
       runsMeta.value = result.meta
     } catch (e: any) {
@@ -153,14 +147,12 @@ export const useDriftStore = defineStore('drift', () => {
     }
   }
 
-  // Actions - Drift Reports
-  async function fetchReports(page = 1, pageSize = 25, resolved?: boolean) {
+  async function fetchReports(limit = 50, deviceId?: number, reportType?: string) {
     loading.value = true
     error.value = null
     try {
-      const result = await getDriftReports(page, pageSize, resolved)
-      reports.value = result.items
-      reportMeta.value = result.meta
+      reports.value = await getDriftReports(limit, deviceId, reportType)
+      reportMeta.value = undefined
     } catch (e: any) {
       error.value = e?.message || 'Failed to load drift reports'
       throw e
@@ -169,18 +161,36 @@ export const useDriftStore = defineStore('drift', () => {
     }
   }
 
-  async function resolveReport(id: number | string, notes?: string) {
+  // Per-path drift items (DriftTrend rows). Populates `trends` which the
+  // "Drift Reports" page renders and the "Drift Trends" page aggregates.
+  async function fetchTrends(resolved?: boolean, limit = 500, deviceId?: number) {
     loading.value = true
     error.value = null
     try {
-      const resolved = await resolveDriftReport(id, notes)
-      const index = reports.value.findIndex(r => r.id === resolved.id)
-      if (index !== -1) {
-        reports.value[index] = resolved
-      }
-      return resolved
+      trends.value = await getDriftTrends(limit, resolved, deviceId)
     } catch (e: any) {
-      error.value = e?.message || 'Failed to resolve drift report'
+      error.value = e?.message || 'Failed to load drift trends'
+      throw e
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function resolveTrend(id: number) {
+    loading.value = true
+    error.value = null
+    try {
+      await resolveDriftTrend(id)
+      const index = trends.value.findIndex(t => t.id === id)
+      if (index !== -1) {
+        trends.value[index] = {
+          ...trends.value[index],
+          resolved: true,
+          resolved_at: new Date().toISOString()
+        }
+      }
+    } catch (e: any) {
+      error.value = e?.message || 'Failed to resolve drift item'
       throw e
     } finally {
       loading.value = false
@@ -191,10 +201,9 @@ export const useDriftStore = defineStore('drift', () => {
     loading.value = true
     error.value = null
     try {
-      const deviceReports = await generateDeviceDriftReport(deviceId)
-      // Add new reports to the list
-      reports.value = [...deviceReports, ...reports.value]
-      return deviceReports
+      const report = await generateDeviceDriftReport(deviceId)
+      reports.value = [report, ...reports.value]
+      return report
     } catch (e: any) {
       error.value = e?.message || 'Failed to generate device drift report'
       throw e
@@ -203,21 +212,10 @@ export const useDriftStore = defineStore('drift', () => {
     }
   }
 
-  // Actions - Drift Trends
-  async function fetchTrends(days = 30) {
-    loading.value = true
-    error.value = null
-    try {
-      trends.value = await getDriftTrends(days)
-    } catch (e: any) {
-      error.value = e?.message || 'Failed to load drift trends'
-      throw e
-    } finally {
-      loading.value = false
-    }
+  function setTrendAggregateDays(days: number) {
+    trendAggregateDays.value = days
   }
 
-  // Utility actions
   function clearError() {
     error.value = null
   }
@@ -227,18 +225,18 @@ export const useDriftStore = defineStore('drift', () => {
   }
 
   return {
-    // State
     schedules,
     currentSchedule,
     scheduleRuns,
     reports,
     trends,
+    trendAggregates,
+    trendAggregateDays,
     loading,
     error,
     scheduleMeta,
     reportMeta,
     runsMeta,
-    // Actions
     fetchSchedules,
     fetchSchedule,
     create,
@@ -247,9 +245,10 @@ export const useDriftStore = defineStore('drift', () => {
     toggle,
     fetchScheduleRuns,
     fetchReports,
-    resolveReport,
-    generateReport,
     fetchTrends,
+    resolveTrend,
+    generateReport,
+    setTrendAggregateDays,
     clearError,
     clearCurrentSchedule
   }


### PR DESCRIPTION
## Summary

Aligns the Vue 3 drift-detection UI with the Go backend `DriftDetection*` API. Before this change every schedule created in the UI silently lost its device selection and had no cron schedule; every list page rendered empty; the "Resolve" button hit an endpoint that does not exist; and the trends chart never bound to real data.

The root causes discovered during WS-B verification:

1. **Field-name case mismatch**: TS types used `deviceIds`/`deviceFilter`/`checkInterval`/`lastRun` while the backend model (`internal/configuration/models.go:278-291`) uses `device_ids`/`device_filter`/`cron_spec`/`last_run`. Backend silently dropped unknown keys.
2. **Scheduling model mismatch**: UI offered a `checkInterval` free-text field ("1h"/"24h"); backend validates a full cron expression via `robfig/cron/v3`. All user-entered intervals were ignored.
3. **List-response wrapper mismatch**: TS client unwrapped `res.data.data.schedules` (et al.), but every list endpoint returns a raw array at `res.data.data`. Every page showed empty.
4. **Report/Trend model mismatch**: Frontend modelled `DriftReport` as per-difference rows (`driftType`, `expectedValue`, `actualValue`); backend returns aggregate reports + per-path `DriftTrend` records. The "Drift Reports" page now renders DriftTrend rows — matching both the table shape and the resolve capability.
5. **Empty-body POST rejected by middleware**: `toggle`, `resolve`, and `generate-report` had no body, so axios omitted `Content-Type` and `ValidateContentTypeMiddleware` returned 400. Empty-body POSTs now send `{}` to satisfy the middleware.

### Changes

- `ui/src/api/drift.ts` — TS interfaces rewritten to match backend JSON exactly; list functions unwrap raw arrays; `resolveDriftReport` renamed to `resolveDriftTrend` (backend's `MarkTrendResolved`) with the notes parameter removed (backend ignores the body); new `computeDailyAggregates` helper derives the Trends-page chart data client-side from per-path trends.
- `ui/src/stores/drift.ts` — `fetchTrends` no longer takes a `days` argument; `trendAggregates` is a computed client-side aggregation; `resolveReport` renamed to `resolveTrend`.
- `ui/src/pages/DriftSchedulesPage.vue` — `cron_spec` input replaces `checkInterval`; preset buttons for hourly / every 6h / daily / weekly; card bindings use snake_case.
- `ui/src/pages/DriftReportsPage.vue` — retitled with a "per-device, per-path drift items tracked over time" subhead; columns bound to `DriftTrend` (path / category / severity / first_seen / last_seen / occurrences); resolve dialog drops the notes field (backend doesn't persist it).
- `ui/src/pages/DriftTrendsPage.vue` — reads from `store.trendAggregates`; the day-range selector drives `store.setTrendAggregateDays`.
- `ui/src/api/__tests__/drift.test.ts` — rewritten for the new contract (18 tests); includes coverage for `computeDailyAggregates` and for the `{}` bodies on toggle/resolve/generate.

### Not solved by this PR

- **`device_ids` not persisted.** The backend `DriftDetectionSchedule` struct has `gorm:"-"` on `DeviceIDs`, so device selection is accepted on create and echoed back immediately but lost on the next read. Separate backend issue; out of scope.
- **`GetDriftSchedule` returns 500 for missing IDs** instead of 404. Pre-existing, not caused or worsened here.

Fixes/closes #129.

## Test plan

- [x] `npx vitest run src/api/__tests__/drift.test.ts` — 18/18 pass
- [x] `npx vitest run` full suite — 513 pass / 19 skipped
- [x] `npm run build` — clean
- [x] End-to-end against a running backend: create schedule (cron_spec echoed), toggle (enabled flips, 200), generate device drift report (201), list trends (populated with per-path records), resolve trend (status: "resolved", 200), list resolved=true trends (count=1), delete schedule (200).
- [ ] `make test-ci` before merge
- [ ] Manual UI smoke on `/drift/schedules`, `/drift/reports`, `/drift/trends` after hard refresh
