### PR TITLE
feat(api): add UI-facing provisioning task and agent endpoints

### DIFF
--- a/internal/api/provisioning_ui_handlers.go
+++ b/internal/api/provisioning_ui_handlers.go
@@ -1,0 +1,361 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	apiresp "github.com/ginsys/shelly-manager/internal/api/response"
+)
+
+// UI-facing DTOs for the `/api/v1/provisioning/*` endpoints. Backend stores
+// tasks/agents in the in-memory `registry` (see provisioner_handlers.go) with
+// snake_case field names and agent-oriented status vocabulary; the UI expects
+// camelCase fields and a coarser status set. These DTOs + translators bridge
+// the two so the frontend contract stays stable.
+
+type uiProvisioningTask struct {
+	ID            string                 `json:"id"`
+	DeviceID      string                 `json:"deviceId,omitempty"`
+	DeviceName    string                 `json:"deviceName,omitempty"`
+	Status        string                 `json:"status"`
+	TaskType      string                 `json:"taskType"`
+	Configuration map[string]interface{} `json:"config,omitempty"`
+	Result        map[string]interface{} `json:"result,omitempty"`
+	Error         string                 `json:"error,omitempty"`
+	CreatedAt     time.Time              `json:"createdAt"`
+	UpdatedAt     time.Time              `json:"updatedAt"`
+}
+
+type uiProvisioningAgent struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	Status       string    `json:"status"`
+	Version      string    `json:"version"`
+	Capabilities []string  `json:"capabilities"`
+	LastSeen     time.Time `json:"lastSeen"`
+}
+
+type uiCreateTaskRequest struct {
+	DeviceID      string                 `json:"deviceId"`
+	TaskType      string                 `json:"taskType"`
+	Configuration map[string]interface{} `json:"config,omitempty"`
+}
+
+type uiBulkProvisionRequest struct {
+	DeviceIDs     []string               `json:"deviceIds"`
+	Configuration map[string]interface{} `json:"config,omitempty"`
+}
+
+// mapInternalToUIStatus collapses internal task statuses into the four
+// values the UI filter/state machine expects.
+func mapInternalToUIStatus(internal string) string {
+	switch internal {
+	case "assigned", "in_progress":
+		return "running"
+	case "pending", "completed", "failed":
+		return internal
+	default:
+		return internal
+	}
+}
+
+// agentStatus derives the UI-facing agent status from LastSeen timestamp,
+// mirroring the 5-minute freshness threshold used elsewhere in the registry.
+func agentStatus(agent *ProvisionerAgent) string {
+	if time.Since(agent.LastSeen) > 5*time.Minute {
+		return "offline"
+	}
+	if agent.Status != "" {
+		return agent.Status
+	}
+	return "online"
+}
+
+// toUITask translates an internal ProvisioningTask to its UI representation.
+// deviceName is resolved by MAC lookup when the task carries DeviceMAC.
+func (h *Handler) toUITask(task *ProvisioningTask) uiProvisioningTask {
+	out := uiProvisioningTask{
+		ID:            task.ID,
+		Status:        mapInternalToUIStatus(task.Status),
+		TaskType:      task.Type,
+		Configuration: task.Config,
+		CreatedAt:     task.CreatedAt,
+		UpdatedAt:     task.UpdatedAt,
+	}
+
+	if task.DeviceMAC != "" && h.DB != nil {
+		if dev, err := h.DB.GetDeviceByMAC(task.DeviceMAC); err == nil && dev != nil {
+			out.DeviceID = strconv.FormatUint(uint64(dev.ID), 10)
+			out.DeviceName = dev.Name
+		}
+	}
+
+	if result, ok := task.Config["_result"].(map[string]interface{}); ok {
+		out.Result = result
+	}
+	if errMsg, ok := task.Config["_error"].(string); ok {
+		out.Error = errMsg
+	}
+
+	return out
+}
+
+func toUIAgent(agent *ProvisionerAgent) uiProvisioningAgent {
+	capabilities := agent.Capabilities
+	if capabilities == nil {
+		capabilities = []string{}
+	}
+	return uiProvisioningAgent{
+		ID:           agent.ID,
+		Name:         agent.Hostname,
+		Status:       agentStatus(agent),
+		Version:      agent.Version,
+		Capabilities: capabilities,
+		LastSeen:     agent.LastSeen,
+	}
+}
+
+// resolveDeviceMAC looks up the MAC address for a numeric device ID carried
+// in a UI request. Empty deviceId is allowed (task may target any agent).
+func (h *Handler) resolveDeviceMAC(deviceID string) (string, error) {
+	if deviceID == "" {
+		return "", nil
+	}
+	id, err := strconv.ParseUint(deviceID, 10, 32)
+	if err != nil {
+		return "", fmt.Errorf("deviceId must be a numeric device id")
+	}
+	dev, err := h.DB.GetDevice(uint(id))
+	if err != nil {
+		return "", fmt.Errorf("device not found")
+	}
+	return dev.MAC, nil
+}
+
+// ListProvisioningTasksUI handles GET /api/v1/provisioning/tasks
+func (h *Handler) ListProvisioningTasksUI(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	statusFilter := r.URL.Query().Get("status")
+
+	registry.mu.RLock()
+	tasks := make([]*ProvisioningTask, 0, len(registry.tasks))
+	for _, task := range registry.tasks {
+		tasks = append(tasks, task)
+	}
+	registry.mu.RUnlock()
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].CreatedAt.After(tasks[j].CreatedAt)
+	})
+
+	uiTasks := make([]uiProvisioningTask, 0, len(tasks))
+	for _, t := range tasks {
+		ui := h.toUITask(t)
+		if statusFilter != "" && ui.Status != statusFilter {
+			continue
+		}
+		uiTasks = append(uiTasks, ui)
+	}
+
+	h.responseWriter().WriteSuccess(w, r, map[string]interface{}{
+		"tasks": uiTasks,
+		"count": len(uiTasks),
+	})
+}
+
+// GetProvisioningTaskUI handles GET /api/v1/provisioning/tasks/{id}
+func (h *Handler) GetProvisioningTaskUI(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	id := mux.Vars(r)["id"]
+	registry.mu.RLock()
+	task, ok := registry.tasks[id]
+	registry.mu.RUnlock()
+	if !ok {
+		h.responseWriter().WriteNotFoundError(w, r, "Provisioning task")
+		return
+	}
+
+	h.responseWriter().WriteSuccess(w, r, h.toUITask(task))
+}
+
+// CreateProvisioningTaskUI handles POST /api/v1/provisioning/tasks
+func (h *Handler) CreateProvisioningTaskUI(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	var req uiCreateTaskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.responseWriter().WriteValidationError(w, r, "Invalid JSON request body")
+		return
+	}
+	if req.TaskType == "" {
+		h.responseWriter().WriteValidationError(w, r, "taskType is required")
+		return
+	}
+
+	mac, err := h.resolveDeviceMAC(req.DeviceID)
+	if err != nil {
+		h.responseWriter().WriteValidationError(w, r, err.Error())
+		return
+	}
+
+	task := h.createTaskLocked(req.TaskType, mac, req.Configuration)
+	h.responseWriter().WriteCreated(w, r, h.toUITask(task))
+}
+
+// createTaskLocked builds and inserts a ProvisioningTask into the registry.
+// Separated so BulkProvisionUI can reuse the insertion logic.
+func (h *Handler) createTaskLocked(taskType, deviceMAC string, config map[string]interface{}) *ProvisioningTask {
+	taskID := fmt.Sprintf("task_%d", time.Now().UnixNano())
+	if config == nil {
+		config = map[string]interface{}{}
+	}
+	now := time.Now()
+	task := &ProvisioningTask{
+		ID:        taskID,
+		Type:      taskType,
+		DeviceMAC: deviceMAC,
+		Config:    config,
+		Status:    "pending",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	registry.mu.Lock()
+	registry.tasks[taskID] = task
+	registry.mu.Unlock()
+
+	h.logger.WithFields(map[string]any{
+		"task_id":    taskID,
+		"task_type":  taskType,
+		"device_mac": deviceMAC,
+		"component":  "provisioning_ui",
+	}).Info("UI-initiated provisioning task created")
+
+	return task
+}
+
+// CancelProvisioningTaskUI handles POST /api/v1/provisioning/tasks/{id}/cancel
+//
+// For unassigned tasks this is a clean flip to "failed" with error="canceled".
+// Tasks already picked up by an agent are cancelled best-effort — the agent
+// will push its final status on completion and overwrite ours. Changing that
+// behaviour would require extending the agent protocol (out of scope here).
+func (h *Handler) CancelProvisioningTaskUI(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	id := mux.Vars(r)["id"]
+	registry.mu.Lock()
+	task, ok := registry.tasks[id]
+	if !ok {
+		registry.mu.Unlock()
+		h.responseWriter().WriteNotFoundError(w, r, "Provisioning task")
+		return
+	}
+	if task.Status == "pending" || task.Status == "assigned" || task.Status == "in_progress" {
+		task.Status = "failed"
+		task.UpdatedAt = time.Now()
+		if task.Config == nil {
+			task.Config = map[string]interface{}{}
+		}
+		task.Config["_error"] = "canceled"
+	}
+	taskCopy := *task
+	registry.mu.Unlock()
+
+	h.responseWriter().WriteSuccess(w, r, h.toUITask(&taskCopy))
+}
+
+// BulkProvisionUI handles POST /api/v1/provisioning/bulk
+func (h *Handler) BulkProvisionUI(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	var req uiBulkProvisionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.responseWriter().WriteValidationError(w, r, "Invalid JSON request body")
+		return
+	}
+	if len(req.DeviceIDs) == 0 {
+		h.responseWriter().WriteValidationError(w, r, "deviceIds must contain at least one device id")
+		return
+	}
+
+	uiTasks := make([]uiProvisioningTask, 0, len(req.DeviceIDs))
+	for _, devID := range req.DeviceIDs {
+		mac, err := h.resolveDeviceMAC(devID)
+		if err != nil {
+			h.responseWriter().WriteError(w, r, http.StatusBadRequest, apiresp.ErrCodeBadRequest,
+				fmt.Sprintf("device %q: %s", devID, err.Error()), nil)
+			return
+		}
+		task := h.createTaskLocked("configure", mac, req.Configuration)
+		uiTasks = append(uiTasks, h.toUITask(task))
+	}
+
+	h.responseWriter().WriteCreated(w, r, map[string]interface{}{
+		"tasks": uiTasks,
+		"count": len(uiTasks),
+	})
+}
+
+// ListProvisioningAgentsUI handles GET /api/v1/provisioning/agents
+func (h *Handler) ListProvisioningAgentsUI(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	registry.mu.RLock()
+	agents := make([]*ProvisionerAgent, 0, len(registry.agents))
+	for _, a := range registry.agents {
+		agents = append(agents, a)
+	}
+	registry.mu.RUnlock()
+
+	sort.Slice(agents, func(i, j int) bool {
+		return agents[i].Hostname < agents[j].Hostname
+	})
+
+	uiAgents := make([]uiProvisioningAgent, 0, len(agents))
+	for _, a := range agents {
+		uiAgents = append(uiAgents, toUIAgent(a))
+	}
+
+	h.responseWriter().WriteSuccess(w, r, map[string]interface{}{
+		"agents": uiAgents,
+		"count":  len(uiAgents),
+	})
+}
+
+// GetProvisioningAgentStatusUI handles GET /api/v1/provisioning/agents/{id}/status
+func (h *Handler) GetProvisioningAgentStatusUI(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	id := mux.Vars(r)["id"]
+	registry.mu.RLock()
+	agent, ok := registry.agents[id]
+	registry.mu.RUnlock()
+	if !ok {
+		h.responseWriter().WriteNotFoundError(w, r, "Provisioning agent")
+		return
+	}
+
+	h.responseWriter().WriteSuccess(w, r, toUIAgent(agent))
+}

--- a/internal/api/provisioning_ui_handlers_test.go
+++ b/internal/api/provisioning_ui_handlers_test.go
@@ -1,0 +1,374 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ginsys/shelly-manager/internal/database"
+	"github.com/ginsys/shelly-manager/internal/logging"
+	"github.com/ginsys/shelly-manager/internal/testutil"
+)
+
+// resetProvisioningRegistry clears the in-memory agents/tasks maps for
+// isolated handler tests. Kept local to the test file so production paths
+// cannot accidentally wipe state.
+func resetProvisioningRegistry() {
+	registry.mu.Lock()
+	defer registry.mu.Unlock()
+	registry.agents = make(map[string]*ProvisionerAgent)
+	registry.tasks = make(map[string]*ProvisioningTask)
+}
+
+func newTestHandler(t *testing.T) (*Handler, *database.Manager) {
+	t.Helper()
+	db, cleanup := testutil.TestDatabase(t)
+	t.Cleanup(cleanup)
+	svc := testShellyService(t, db)
+	nh := testNotificationHandler(t, db)
+	return NewHandlerWithLogger(db, svc, nh, nil, logging.GetDefault()), db
+}
+
+func seedDevice(t *testing.T, db *database.Manager, ip, mac, name string) *database.Device {
+	t.Helper()
+	d := &database.Device{IP: ip, MAC: mac, Name: name, Type: "Shelly1"}
+	require.NoError(t, db.AddDevice(d))
+	return d
+}
+
+func TestListProvisioningTasksUI_EmptyThenPopulated(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	// Empty
+	req := httptest.NewRequest("GET", "/api/v1/provisioning/tasks", nil)
+	w := httptest.NewRecorder()
+	h.ListProvisioningTasksUI(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var env struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Tasks []uiProvisioningTask `json:"tasks"`
+			Count int                  `json:"count"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.True(t, env.Success)
+	assert.Equal(t, 0, env.Data.Count)
+	assert.Empty(t, env.Data.Tasks)
+
+	// Seed a task directly in the registry
+	registry.mu.Lock()
+	registry.tasks["task_abc"] = &ProvisioningTask{
+		ID: "task_abc", Type: "configure", Status: "pending",
+		Config: map[string]interface{}{}, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	registry.mu.Unlock()
+
+	w = httptest.NewRecorder()
+	h.ListProvisioningTasksUI(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	env.Data.Tasks = nil
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Len(t, env.Data.Tasks, 1)
+	assert.Equal(t, "task_abc", env.Data.Tasks[0].ID)
+	assert.Equal(t, "pending", env.Data.Tasks[0].Status)
+}
+
+func TestListProvisioningTasksUI_StatusFilterAndMapping(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	now := time.Now()
+	registry.mu.Lock()
+	registry.tasks["t1"] = &ProvisioningTask{ID: "t1", Type: "configure", Status: "pending", CreatedAt: now}
+	registry.tasks["t2"] = &ProvisioningTask{ID: "t2", Type: "configure", Status: "assigned", CreatedAt: now}
+	registry.tasks["t3"] = &ProvisioningTask{ID: "t3", Type: "configure", Status: "in_progress", CreatedAt: now}
+	registry.tasks["t4"] = &ProvisioningTask{ID: "t4", Type: "configure", Status: "completed", CreatedAt: now}
+	registry.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/v1/provisioning/tasks?status=running", nil)
+	w := httptest.NewRecorder()
+	h.ListProvisioningTasksUI(w, req)
+
+	var env struct {
+		Data struct {
+			Tasks []uiProvisioningTask `json:"tasks"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	// assigned + in_progress both map to running
+	ids := []string{}
+	for _, task := range env.Data.Tasks {
+		assert.Equal(t, "running", task.Status)
+		ids = append(ids, task.ID)
+	}
+	assert.ElementsMatch(t, []string{"t2", "t3"}, ids)
+}
+
+func TestGetProvisioningTaskUI_FoundAndMissing(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	registry.mu.Lock()
+	registry.tasks["task_xyz"] = &ProvisioningTask{
+		ID: "task_xyz", Type: "update", Status: "completed",
+		CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	registry.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/v1/provisioning/tasks/task_xyz", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "task_xyz"})
+	w := httptest.NewRecorder()
+	h.GetProvisioningTaskUI(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Missing
+	req = httptest.NewRequest("GET", "/api/v1/provisioning/tasks/nope", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "nope"})
+	w = httptest.NewRecorder()
+	h.GetProvisioningTaskUI(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCreateProvisioningTaskUI_ResolvesDeviceMAC(t *testing.T) {
+	resetProvisioningRegistry()
+	h, db := newTestHandler(t)
+
+	dev := seedDevice(t, db, "10.0.0.1", "AA:BB:CC:DD:EE:01", "Living Room")
+
+	body := map[string]interface{}{
+		"deviceId": strconv.FormatUint(uint64(dev.ID), 10),
+		"taskType": "configure",
+		"config":   map[string]interface{}{"ssid": "Home"},
+	}
+	bodyJSON, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST", "/api/v1/provisioning/tasks", bytes.NewReader(bodyJSON))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CreateProvisioningTaskUI(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var env struct {
+		Data uiProvisioningTask `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, "configure", env.Data.TaskType)
+	assert.Equal(t, "pending", env.Data.Status)
+	assert.Equal(t, strconv.FormatUint(uint64(dev.ID), 10), env.Data.DeviceID)
+	assert.Equal(t, "Living Room", env.Data.DeviceName)
+
+	// Confirm task got inserted with the MAC resolved from deviceId
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	require.Len(t, registry.tasks, 1)
+	for _, task := range registry.tasks {
+		assert.Equal(t, dev.MAC, task.DeviceMAC)
+	}
+}
+
+func TestCreateProvisioningTaskUI_ValidationErrors(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{"invalid json", "not-json", http.StatusBadRequest},
+		{"missing taskType", `{"deviceId":"1"}`, http.StatusBadRequest},
+		{"unknown device", `{"deviceId":"9999","taskType":"configure"}`, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/api/v1/provisioning/tasks", bytes.NewReader([]byte(tc.body)))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+			h.CreateProvisioningTaskUI(w, req)
+			assert.Equal(t, tc.want, w.Code)
+		})
+	}
+}
+
+func TestCancelProvisioningTaskUI(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	registry.mu.Lock()
+	registry.tasks["t_pending"] = &ProvisioningTask{ID: "t_pending", Type: "configure", Status: "pending", Config: map[string]interface{}{}}
+	registry.tasks["t_done"] = &ProvisioningTask{ID: "t_done", Type: "configure", Status: "completed", Config: map[string]interface{}{}}
+	registry.mu.Unlock()
+
+	for _, id := range []string{"t_pending", "t_done"} {
+		req := httptest.NewRequest("POST", "/api/v1/provisioning/tasks/"+id+"/cancel", nil)
+		req = mux.SetURLVars(req, map[string]string{"id": id})
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		h.CancelProvisioningTaskUI(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	registry.mu.RLock()
+	defer registry.mu.RUnlock()
+	assert.Equal(t, "failed", registry.tasks["t_pending"].Status)
+	assert.Equal(t, "canceled", registry.tasks["t_pending"].Config["_error"])
+	// Completed task untouched
+	assert.Equal(t, "completed", registry.tasks["t_done"].Status)
+}
+
+func TestCancelProvisioningTaskUI_NotFound(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	req := httptest.NewRequest("POST", "/api/v1/provisioning/tasks/nope/cancel", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "nope"})
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.CancelProvisioningTaskUI(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestBulkProvisionUI(t *testing.T) {
+	resetProvisioningRegistry()
+	h, db := newTestHandler(t)
+
+	d1 := seedDevice(t, db, "10.0.0.1", "AA:BB:CC:DD:EE:01", "dev1")
+	d2 := seedDevice(t, db, "10.0.0.2", "AA:BB:CC:DD:EE:02", "dev2")
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"deviceIds": []string{
+			strconv.FormatUint(uint64(d1.ID), 10),
+			strconv.FormatUint(uint64(d2.ID), 10),
+		},
+		"config": map[string]interface{}{"ssid": "HomeNet"},
+	})
+	req := httptest.NewRequest("POST", "/api/v1/provisioning/bulk", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.BulkProvisionUI(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	var env struct {
+		Data struct {
+			Tasks []uiProvisioningTask `json:"tasks"`
+			Count int                  `json:"count"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	assert.Equal(t, 2, env.Data.Count)
+	assert.Len(t, env.Data.Tasks, 2)
+}
+
+func TestBulkProvisionUI_EmptyIDs(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	req := httptest.NewRequest("POST", "/api/v1/provisioning/bulk",
+		bytes.NewReader([]byte(`{"deviceIds":[]}`)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.BulkProvisionUI(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListProvisioningAgentsUI_FieldTranslation(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	now := time.Now()
+	registry.mu.Lock()
+	registry.agents["a1"] = &ProvisionerAgent{
+		ID: "a1", Hostname: "alpha", IP: "10.0.0.5", Version: "v1.2.3",
+		Capabilities: []string{"wifi"}, Status: "online", LastSeen: now, RegisteredAt: now,
+	}
+	registry.agents["a2"] = &ProvisionerAgent{
+		ID: "a2", Hostname: "bravo", Status: "online",
+		LastSeen: now.Add(-10 * time.Minute), RegisteredAt: now.Add(-time.Hour),
+	}
+	registry.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/v1/provisioning/agents", nil)
+	w := httptest.NewRecorder()
+	h.ListProvisioningAgentsUI(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var env struct {
+		Data struct {
+			Agents []uiProvisioningAgent `json:"agents"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &env))
+	require.Len(t, env.Data.Agents, 2)
+
+	byID := map[string]uiProvisioningAgent{}
+	for _, a := range env.Data.Agents {
+		byID[a.ID] = a
+	}
+	assert.Equal(t, "alpha", byID["a1"].Name)
+	assert.Equal(t, "online", byID["a1"].Status)
+	assert.Equal(t, "offline", byID["a2"].Status) // derived from stale LastSeen
+}
+
+func TestGetProvisioningAgentStatusUI(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+
+	registry.mu.Lock()
+	registry.agents["a1"] = &ProvisionerAgent{ID: "a1", Hostname: "alpha", Status: "online", LastSeen: time.Now()}
+	registry.mu.Unlock()
+
+	req := httptest.NewRequest("GET", "/api/v1/provisioning/agents/a1/status", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "a1"})
+	w := httptest.NewRecorder()
+	h.GetProvisioningAgentStatusUI(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	req = httptest.NewRequest("GET", "/api/v1/provisioning/agents/missing/status", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "missing"})
+	w = httptest.NewRecorder()
+	h.GetProvisioningAgentStatusUI(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestProvisioningUI_RequiresAdminWhenKeyConfigured(t *testing.T) {
+	resetProvisioningRegistry()
+	h, _ := newTestHandler(t)
+	h.SetAdminAPIKey("secret")
+	t.Cleanup(func() { h.SetAdminAPIKey("") })
+
+	req := httptest.NewRequest("GET", "/api/v1/provisioning/tasks", nil)
+	w := httptest.NewRecorder()
+	h.ListProvisioningTasksUI(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// With valid bearer
+	req = httptest.NewRequest("GET", "/api/v1/provisioning/tasks", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	w = httptest.NewRecorder()
+	h.ListProvisioningTasksUI(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestMapInternalToUIStatus(t *testing.T) {
+	cases := map[string]string{
+		"pending":     "pending",
+		"assigned":    "running",
+		"in_progress": "running",
+		"completed":   "completed",
+		"failed":      "failed",
+		"other":       "other",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, mapInternalToUIStatus(in), "input=%s", in)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -286,6 +286,15 @@ func SetupRoutesWithSecurity(handler *Handler, logger *logging.Logger, securityC
 	api.HandleFunc("/provisioning/status", handler.GetProvisioningStatus).Methods("GET")
 	api.HandleFunc("/provisioning/provision", handler.ProvisionDevices).Methods("POST")
 
+	// UI-facing provisioning task/agent routes (admin-key auth)
+	api.HandleFunc("/provisioning/tasks", handler.ListProvisioningTasksUI).Methods("GET")
+	api.HandleFunc("/provisioning/tasks", handler.CreateProvisioningTaskUI).Methods("POST")
+	api.HandleFunc("/provisioning/tasks/{id}", handler.GetProvisioningTaskUI).Methods("GET")
+	api.HandleFunc("/provisioning/tasks/{id}/cancel", handler.CancelProvisioningTaskUI).Methods("POST")
+	api.HandleFunc("/provisioning/bulk", handler.BulkProvisionUI).Methods("POST")
+	api.HandleFunc("/provisioning/agents", handler.ListProvisioningAgentsUI).Methods("GET")
+	api.HandleFunc("/provisioning/agents/{id}/status", handler.GetProvisioningAgentStatusUI).Methods("GET")
+
 	// Provisioner agent management routes
 	api.HandleFunc("/provisioner/agents/register", handler.RegisterAgent).Methods("POST")
 	api.HandleFunc("/provisioner/agents", handler.GetProvisionerAgents).Methods("GET")

--- a/ui/src/api/__tests__/provisioning.test.ts
+++ b/ui/src/api/__tests__/provisioning.test.ts
@@ -137,7 +137,9 @@ describe('provisioning api', () => {
       })
 
       await cancelTask('1')
-      expect(api.post).toHaveBeenCalledWith('/provisioning/tasks/1/cancel')
+      // Empty {} body is sent so axios emits Content-Type for the backend's
+      // ValidateContentTypeMiddleware.
+      expect(api.post).toHaveBeenCalledWith('/provisioning/tasks/1/cancel', {})
     })
 
     it('getTasks throws error on API failure', async () => {

--- a/ui/src/api/provisioning.ts
+++ b/ui/src/api/provisioning.ts
@@ -63,7 +63,9 @@ export async function createTask(data: Partial<ProvisioningTask>): Promise<Provi
 }
 
 export async function cancelTask(id: string): Promise<void> {
-  const res = await api.post<APIResponse<void>>(`/provisioning/tasks/${id}/cancel`)
+  // Empty-body POST: pass {} so axios emits Content-Type for the backend's
+  // ValidateContentTypeMiddleware.
+  const res = await api.post<APIResponse<void>>(`/provisioning/tasks/${id}/cancel`, {})
   if (!res.data.success) {
     const msg = res.data.error?.message || 'Failed to cancel provisioning task'
     throw new Error(msg)


### PR DESCRIPTION
## Summary

Adds the seven `/api/v1/provisioning/*` endpoints the Vue UI has been calling into the void. The frontend surface (API client, Pinia store, four pages) was scaffolded long ago but every call failed because none of the matching backend routes existed. Internal state lives in the in-memory `registry` under `/api/v1/provisioner/*` (agent-to-server protocol) with snake_case fields and a finer-grained status vocabulary the UI doesn't speak; this change introduces a thin adapter layer, not a rewrite.

### Endpoints

| Method | Path | Handler |
| --- | --- | --- |
| GET | `/provisioning/tasks` (`?status=`) | `ListProvisioningTasksUI` |
| POST | `/provisioning/tasks` | `CreateProvisioningTaskUI` |
| GET | `/provisioning/tasks/{id}` | `GetProvisioningTaskUI` |
| POST | `/provisioning/tasks/{id}/cancel` | `CancelProvisioningTaskUI` |
| POST | `/provisioning/bulk` | `BulkProvisionUI` |
| GET | `/provisioning/agents` | `ListProvisioningAgentsUI` |
| GET | `/provisioning/agents/{id}/status` | `GetProvisioningAgentStatusUI` |

### Key design choices

- Routes sit under the existing `/api/v1` subrouter, inheriting the full middleware stack. Each handler calls `h.requireAdmin` as its first statement, mirroring `sync_handlers.go`.
- snake_case internal ↔ camelCase UI translation via DTOs in `provisioning_ui_handlers.go`.
- **Status mapping**: internal `assigned` + `in_progress` → UI `running`; `pending` / `completed` / `failed` pass through unchanged.
- **deviceId resolution**: the UI sends numeric device-id strings; the backend resolves them to `DeviceMAC` via `DB.GetDevice` on create, and back to `deviceId`/`deviceName` via `DB.GetDeviceByMAC` on read.
- **Cancel semantics**: for `pending`/`assigned`/`in_progress` the task is flipped to `failed` with `_error: "canceled"`. Tasks an agent has already picked up are cancelled best-effort; the agent overwrites on completion. Documented in the handler comment; agent protocol is **not** changed.
- **Empty-body POST fix on the frontend**: `cancelTask` now sends `{}` so axios emits `Content-Type` and the backend's `ValidateContentTypeMiddleware` accepts the call — same pattern used in the drift PR (#187).

### Out of scope (explicit non-goals)

- **No DB persistence**. The in-memory `registry` still loses all tasks/agents on restart. Moving it to DB is a separate concern.
- Legacy `/provisioning/status` and `/provisioning/provision` stubs are untouched.

### Tests

`internal/api/provisioning_ui_handlers_test.go` — 11 tests:
- Empty-then-populated listing
- Status filter + `assigned`/`in_progress` → `running` mapping
- 404 paths for task and agent lookups
- `deviceId` → `MAC` resolution on create
- Validation errors (invalid JSON, missing `taskType`, unknown device)
- Cancel transitions (pending + completed) and 404 on unknown id
- Bulk insertion and empty-ids rejection
- Agent field translation with `LastSeen`-derived `offline` status
- Admin-key enforcement (401 without, 200 with bearer)
- `mapInternalToUIStatus` table

Fixes/closes #128.

## Test plan

- [x] `go test ./internal/api/... -skip 'TestAPIRouter'` — all pass (TestAPIRouter is a pre-existing failure on main, security middleware flags empty User-Agent — not touched here)
- [x] `npx vitest run` — 532/532 pass
- [x] `go vet` + `golangci-lint` — 0 issues
- [x] `npm run build` — clean
- [ ] End-to-end curl smoke against a running backend (pending restart)
- [ ] Manual UI smoke on `/provisioning/dashboard`, `/provisioning/tasks`, `/provisioning/agents` after hard refresh
- [ ] `make test-ci` before merge
