### PR TITLE
chore(deps): automerge patch/minor dependabot PRs + broader grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,20 @@ updates:
         dependency-type: "production"
         exclude-patterns:
           - "golang.org/x/*"
+      # Catch-all: bundle remaining non-major version updates into one PR
+      gomod-all:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "golang.org/x/*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Bundle all security updates into a single PR
+      gomod-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     # TEMPORARY: Ignore major AND minor updates for golang.org/x/* packages
     # These packages often require newer Go versions (e.g., x/text v0.31.0+ requires Go 1.24.0)
     #
@@ -76,6 +90,18 @@ updates:
           - "terser"
           - "jsdom"
           - "autoprefixer"
+      # Catch-all: bundle remaining non-major version updates into one PR
+      npm-all:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Bundle all security updates into a single PR
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     # TEMPORARY: Ignore major updates for vite/vitest ecosystem
     # Major updates often have peer dependency conflicts (e.g., @vitest/coverage-v8 v4 requires vitest v4)
     # and may require coordinated upgrades of all related packages
@@ -113,6 +139,11 @@ updates:
     groups:
       # Group all GitHub Actions together
       all-actions:
+        patterns:
+          - "*"
+      # Bundle all security updates into a single PR
+      actions-security:
+        applies-to: security-updates
         patterns:
           - "*"
     open-pull-requests-limit: 5

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,29 @@
+name: Dependabot Automerge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      # Moderate scope: patch + minor only. Majors (and grouped PRs whose
+      # highest bump is major) fall through and stay manual.
+      - name: Approve and enable auto-merge for patch/minor
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/dependabot-automerge.yml`: approves and enables auto-merge for **patch/minor** Dependabot PRs (majors stay manual), gated by existing required CI via `gh pr merge --auto`.
- Broaden `.github/dependabot.yml` grouping: add catch-all version-update groups (`gomod-all`, `npm-all`) so leftover deps (e.g. `axios`) bundle into one PR per ecosystem, and per-ecosystem `*-security` groups to consolidate security PRs. Existing named groups and `ignore` rules unchanged.

## Required manual setup before this works (GitHub UI)

- [x] Settings → General → enable **Allow auto-merge**
- [x] Add `PAT_TOKEN` as a **Dependabot** secret (Settings → Secrets → Dependabot; same value as the existing Actions secret) — Dependabot-triggered runs don't get regular Actions secrets
- [x] Confirm branch protection on `main` requires the PR status checks (`test`, `vitest`, `security`, `build`, `e2e-dev`, CodeQL `analyze`) so `--auto` actually gates on them

## Notes

- Scope = "Moderate": patch + minor automerge in all three ecosystems; majors always manual.
- Uses `PAT_TOKEN` (not `GITHUB_TOKEN`) so the merge cascades downstream: triggers `test.yml` on `main`, `docker-build.yml`, and `auto-rebase.yml` (which rebases other open non-Dependabot PR branches — expected, pre-existing behavior).
- Does not change `golang.org/x/*` or `vite/vitest` ignore rules; does not retroactively merge already-open PRs.