### PR TITLE
fix(ci): use rebase merge in dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -26,4 +26,4 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
+          gh pr merge --auto --rebase "$PR_URL"


### PR DESCRIPTION
Repo only allows rebase merging. The automerge workflow added in #205 hardcoded `--squash`, causing `enablePullRequestAutoMerge` to fail with "Merge method squash merging is not allowed on this repository".

Changes `gh pr merge --auto --squash` → `--rebase`.

PAT permission issue (separate, `addPullRequestReview` 403) was resolved out-of-band by granting Pull requests: write.